### PR TITLE
Normalize auth flow email handling and cover with tests

### DIFF
--- a/services/api/app/api/routes/auth.py
+++ b/services/api/app/api/routes/auth.py
@@ -1,26 +1,38 @@
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+
+from app.api.deps import get_db_session
+from app.core.security import create_jwt_token, get_password_hash, verify_password
+from app.models.user import User
 from app.schemas.auth import LoginIn, Token
 from app.schemas.user import UserCreate, UserOut
-from app.models.user import User
-from app.core.security import get_password_hash, verify_password, create_jwt_token
-from app.db.session import get_db
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-@router.post("/register", response_model=UserOut)
-def register(data: UserCreate, db: Session = Depends(get_db)):
-    if db.query(User).filter(User.email == data.email).first():
-        raise HTTPException(status_code=400, detail="Email already registered")
-    user = User(email=data.email, hashed_password=get_password_hash(data.password))
+@router.post("/register", response_model=UserOut, status_code=status.HTTP_201_CREATED)
+def register(data: UserCreate, db: Session = Depends(get_db_session)) -> UserOut:
+    email = data.email.strip().lower()
+
+    user = User(email=email, hashed_password=get_password_hash(data.password))
     db.add(user)
-    db.commit()
+
+    try:
+        db.commit()
+    except IntegrityError as exc:  # pragma: no cover - extra guard for race conditions
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered"
+        ) from exc
+
     db.refresh(user)
     return user
 
 @router.post("/login", response_model=Token)
-def login(data: LoginIn, db: Session = Depends(get_db)):
-    user = db.query(User).filter(User.email == data.email).first()
+def login(data: LoginIn, db: Session = Depends(get_db_session)) -> Token:
+    email = data.email.strip().lower()
+
+    user = db.query(User).filter(User.email == email).first()
     if not user or not verify_password(data.password, user.hashed_password):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
     token = create_jwt_token(str(user.id))

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -1,0 +1,48 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.api.deps import get_db_session
+from app.main import app
+from app.db.base import Base
+from app.db.session import get_db
+
+
+engine = create_engine("sqlite+pysqlite:///:memory:", connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+app.dependency_overrides[get_db_session] = override_get_db
+
+client = TestClient(app)
+
+
+def test_register_and_login_flow():
+    register_response = client.post(
+        "/api/auth/register",
+        json={"email": "User@example.com", "password": "password123"},
+    )
+    assert register_response.status_code == 201
+    data = register_response.json()
+    assert data["email"] == "user@example.com"
+    assert data["role"] == "user"
+    assert "id" in data
+
+    login_response = client.post(
+        "/api/auth/login",
+        json={"email": "USER@example.com", "password": "password123"},
+    )
+    assert login_response.status_code == 200
+    token_data = login_response.json()
+    assert token_data["token_type"] == "bearer"
+    assert token_data["access_token"]


### PR DESCRIPTION
## Summary
- normalize emails during registration and login while sharing the common DB session dependency
- guard against duplicate registration with an integrity-safe error response
- add a FastAPI integration test that covers the register/login flow against an in-memory SQLite database

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi'; dependencies unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e646650ec88324b28048f9b39fb909