### PR TITLE
Implement category management and link questions to categories

### DIFF
--- a/apps/web/src/pages/Practice.vue
+++ b/apps/web/src/pages/Practice.vue
@@ -23,6 +23,8 @@ interface PracticeQuestionResponse {
 interface PracticeCategoryDetail {
   slug: string
   name: string
+  description?: string | null
+  icon?: string | null
   total_questions: number
   difficulty: string
   questions: PracticeQuestionResponse[]
@@ -50,6 +52,10 @@ const selectedAnswer = ref<number | null>(null)
 const showResult = ref(false)
 const showExplanation = ref(false)
 
+const fallbackIcon = '📝'
+
+const fallbackDescription = 'Sharpen your understanding with targeted practice questions.'
+
 const fallbackExplanation =
   'Review the concept behind this question and try again for better mastery.'
 
@@ -75,6 +81,8 @@ const transformQuestion = (question: PracticeQuestionResponse): PracticeQuestion
 }
 
 const currentQuestion = computed(() => questions.value[currentIndex.value])
+
+const categoryIcon = computed(() => category.value?.icon?.trim() || fallbackIcon)
 
 const selectAnswer = (optionIndex: number) => {
   if (showResult.value) return
@@ -159,7 +167,7 @@ loadPracticeSet()
 
 <template>
   <section class="space-y-8">
-    <header class="flex items-start gap-4">
+    <header class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
       <RouterLink
         :to="{ name: 'categories' }"
         class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
@@ -167,13 +175,21 @@ loadPracticeSet()
         <span aria-hidden="true">←</span>
         Back to categories
       </RouterLink>
-      <div>
-        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Practice</p>
-        <h1 class="mt-2 text-3xl font-semibold text-slate-900">{{ category?.name || 'Reinforcement mode' }}</h1>
-        <p class="mt-2 text-sm text-slate-500">
-          {{ category?.difficulty || 'Mixed' }} focus · Question {{ questions.length ? currentIndex + 1 : 0 }} of
-          {{ questions.length }}
-        </p>
+      <div class="flex flex-1 items-start gap-4">
+        <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-900/10 text-2xl">
+          {{ categoryIcon }}
+        </span>
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Practice</p>
+          <h1 class="mt-2 text-3xl font-semibold text-slate-900">{{ category?.name || 'Reinforcement mode' }}</h1>
+          <p class="mt-2 text-sm text-slate-500">
+            {{ category?.description?.trim() || fallbackDescription }}
+          </p>
+          <p class="mt-2 text-xs font-medium uppercase tracking-[0.3em] text-slate-400">
+            {{ category?.difficulty || 'Mixed' }} focus · {{ category?.total_questions ?? questions.length }} questions ·
+            Question {{ questions.length ? currentIndex + 1 : 0 }} of {{ questions.length }}
+          </p>
+        </div>
       </div>
     </header>
 

--- a/apps/web/src/pages/admin/Admin.vue
+++ b/apps/web/src/pages/admin/Admin.vue
@@ -43,12 +43,20 @@ onMounted(load)
             Oversee the entire quiz library, manage question quality, and keep the platform running smoothly for learners.
           </p>
         </div>
-        <RouterLink
-          :to="{ name: 'admin-questions' }"
-          class="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700"
-        >
-          Add question
-        </RouterLink>
+        <div class="flex flex-col gap-3 sm:flex-row">
+          <RouterLink
+            :to="{ name: 'admin-categories' }"
+            class="inline-flex items-center justify-center rounded-full border border-slate-200 px-6 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+          >
+            Manage categories
+          </RouterLink>
+          <RouterLink
+            :to="{ name: 'admin-questions' }"
+            class="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700"
+          >
+            Add question
+          </RouterLink>
+        </div>
       </div>
     </header>
 

--- a/apps/web/src/pages/admin/CategoriesCRUD.vue
+++ b/apps/web/src/pages/admin/CategoriesCRUD.vue
@@ -1,0 +1,268 @@
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue'
+
+import { http } from '../../api/http'
+
+interface AdminCategory {
+  id: number
+  name: string
+  slug: string
+  description?: string | null
+  icon?: string | null
+}
+
+const categories = ref<AdminCategory[]>([])
+const loading = ref(false)
+const formLoading = ref(false)
+const error = ref('')
+const formError = ref('')
+const success = ref('')
+const editingId = ref<number | null>(null)
+
+const totalCategories = computed(() => categories.value.length)
+
+const form = reactive({
+  name: '',
+  description: '',
+  icon: '',
+})
+
+const resetForm = () => {
+  form.name = ''
+  form.description = ''
+  form.icon = ''
+  editingId.value = null
+  formError.value = ''
+  success.value = ''
+}
+
+const loadCategories = async () => {
+  loading.value = true
+  error.value = ''
+  try {
+    const { data } = await http.get<AdminCategory[]>('/categories')
+    categories.value = data
+  } catch (err) {
+    error.value = 'Unable to load categories.'
+    console.error(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+const submit = async () => {
+  formError.value = ''
+  success.value = ''
+
+  const payload = {
+    name: form.name.trim(),
+    description: form.description.trim() ? form.description.trim() : null,
+    icon: form.icon.trim() ? form.icon.trim() : null,
+  }
+
+  if (!payload.name) {
+    formError.value = 'Provide a category name.'
+    return
+  }
+
+  formLoading.value = true
+  try {
+    if (editingId.value) {
+      await http.put(`/categories/${editingId.value}`, payload)
+      success.value = 'Category updated.'
+    } else {
+      await http.post('/categories', payload)
+      success.value = 'Category created.'
+    }
+    await loadCategories()
+    resetForm()
+  } catch (err: any) {
+    formError.value = err?.response?.data?.detail || 'Save failed.'
+  } finally {
+    formLoading.value = false
+  }
+}
+
+const editCategory = (category: AdminCategory) => {
+  form.name = category.name
+  form.description = category.description || ''
+  form.icon = category.icon || ''
+  editingId.value = category.id
+  formError.value = ''
+  success.value = ''
+}
+
+const deleteCategory = async (id: number) => {
+  if (!confirm('Delete this category?')) return
+  formError.value = ''
+  success.value = ''
+  try {
+    await http.delete(`/categories/${id}`)
+    if (editingId.value === id) {
+      resetForm()
+    }
+    await loadCategories()
+    success.value = 'Category removed.'
+  } catch (err: any) {
+    formError.value = err?.response?.data?.detail || 'Unable to delete category.'
+  }
+}
+
+loadCategories()
+</script>
+
+<template>
+  <section class="space-y-10">
+    <header class="space-y-4">
+      <div class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-4 py-1 text-xs font-semibold uppercase tracking-widest text-slate-600">
+        Category library
+      </div>
+      <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h1 class="text-3xl font-semibold text-slate-900">Organize practice categories</h1>
+          <p class="max-w-2xl text-sm text-slate-500">
+            Create topics, assign icons, and keep descriptions up to date so learners always know what they are practicing.
+          </p>
+        </div>
+        <button
+          class="inline-flex items-center justify-center rounded-full border border-slate-200 px-6 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+          type="button"
+          @click="resetForm"
+        >
+          {{ editingId ? 'Cancel editing' : 'Reset form' }}
+        </button>
+      </div>
+    </header>
+
+    <div class="grid gap-5 lg:grid-cols-3">
+      <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Total categories</p>
+        <p class="mt-3 text-3xl font-semibold text-slate-900">{{ totalCategories }}</p>
+        <p class="mt-2 text-xs text-slate-500">Keep practice organized with clear topic areas.</p>
+      </article>
+      <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Featured icon</p>
+        <p class="mt-3 text-3xl font-semibold text-slate-900">
+          {{ categories[0]?.icon || '✨' }}
+        </p>
+        <p class="mt-2 text-xs text-slate-500">Use emoji to make categories instantly recognizable.</p>
+      </article>
+      <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Descriptions</p>
+        <p class="mt-3 text-3xl font-semibold text-slate-900">
+          {{ categories.filter((category) => category.description?.length).length }}
+        </p>
+        <p class="mt-2 text-xs text-slate-500">Add context so learners choose the right focus area.</p>
+      </article>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-[1.1fr,1fr]">
+      <form class="space-y-5 rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-lg backdrop-blur" @submit.prevent="submit">
+        <header class="flex flex-col gap-1">
+          <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">{{ editingId ? 'Update category' : 'New category' }}</p>
+          <h2 class="text-xl font-semibold text-slate-900">{{ editingId ? 'Edit category' : 'Create category' }}</h2>
+        </header>
+        <div class="space-y-2">
+          <label class="text-sm font-semibold text-slate-700" for="name">Name</label>
+          <input
+            id="name"
+            v-model="form.name"
+            class="w-full rounded-2xl border border-slate-300 px-4 py-3 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+            placeholder="General Knowledge"
+            required
+          />
+        </div>
+        <div class="space-y-2">
+          <label class="text-sm font-semibold text-slate-700" for="icon">Icon (emoji)</label>
+          <input
+            id="icon"
+            v-model="form.icon"
+            class="w-full rounded-2xl border border-slate-300 px-4 py-3 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+            placeholder="🌍"
+            maxlength="16"
+          />
+          <p class="text-xs text-slate-500">Pick a single emoji or short symbol.</p>
+        </div>
+        <div class="space-y-2">
+          <label class="text-sm font-semibold text-slate-700" for="description">Description</label>
+          <textarea
+            id="description"
+            v-model="form.description"
+            class="min-h-[120px] w-full rounded-2xl border border-slate-300 px-4 py-3 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+            placeholder="Add context about what this category covers"
+          ></textarea>
+        </div>
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <button
+            class="inline-flex w-full items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 sm:w-auto"
+            :class="{ 'cursor-not-allowed opacity-60': formLoading }"
+            :disabled="formLoading"
+            type="submit"
+          >
+            {{ editingId ? 'Update category' : 'Create category' }}
+          </button>
+          <button
+            class="inline-flex w-full items-center justify-center rounded-full border border-slate-200 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900 sm:w-auto"
+            type="button"
+            @click="resetForm"
+          >
+            Clear form
+          </button>
+        </div>
+        <p v-if="formError" class="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">{{ formError }}</p>
+        <p v-if="success" class="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-600">{{ success }}</p>
+      </form>
+
+      <div class="space-y-4">
+        <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-lg backdrop-blur">
+          <header class="flex items-center justify-between">
+            <div>
+              <h2 class="text-lg font-semibold text-slate-900">Existing categories</h2>
+              <p class="text-xs text-slate-500">{{ totalCategories }} total</p>
+            </div>
+            <span v-if="loading" class="text-xs text-slate-400">Refreshing…</span>
+          </header>
+          <p v-if="loading" class="mt-6 text-sm text-slate-500">Loading categories…</p>
+          <p v-else-if="error" class="mt-6 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">{{ error }}</p>
+          <p v-else-if="categories.length === 0" class="mt-6 text-sm text-slate-500">No categories yet. Create your first topic on the left.</p>
+          <ul v-else class="mt-6 space-y-4 text-sm">
+            <li
+              v-for="category in categories"
+              :key="category.id"
+              class="rounded-2xl border border-slate-200 p-4 shadow-sm"
+            >
+              <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                <div class="space-y-2">
+                  <div class="flex items-center gap-3">
+                    <span class="text-2xl">{{ category.icon || '📝' }}</span>
+                    <div>
+                      <p class="text-base font-semibold text-slate-900">{{ category.name }}</p>
+                      <p class="text-xs uppercase tracking-[0.25em] text-slate-400">{{ category.slug }}</p>
+                    </div>
+                  </div>
+                  <p class="text-sm leading-6 text-slate-600">{{ category.description || 'No description yet.' }}</p>
+                </div>
+                <div class="flex items-center gap-3">
+                  <button
+                    class="rounded-full border border-slate-200 px-4 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+                    type="button"
+                    @click="editCategory(category)"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    class="rounded-full border border-red-200 px-4 py-2 text-xs font-semibold text-red-500 transition hover:bg-red-50"
+                    type="button"
+                    @click="deleteCategory(category.id)"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -44,6 +44,12 @@ const routes = [
     component: () => import('../pages/admin/QuestionsCRUD.vue'),
     meta: { requiresAdmin: true },
   },
+  {
+    path: '/admin/categories',
+    name: 'admin-categories',
+    component: () => import('../pages/admin/CategoriesCRUD.vue'),
+    meta: { requiresAdmin: true },
+  },
   { path: '/login', name: 'login', component: () => import('../pages/auth/Login.vue') },
   { path: '/register', name: 'register', component: () => import('../pages/auth/Register.vue') },
 ]

--- a/services/api/alembic/versions/202409151200_add_categories.py
+++ b/services/api/alembic/versions/202409151200_add_categories.py
@@ -1,0 +1,68 @@
+"""add categories and link questions"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "202409151200"
+down_revision: str | None = "202409011200"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "categories",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=120), nullable=False, unique=True),
+        sa.Column("slug", sa.String(length=160), nullable=False, unique=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("icon", sa.String(length=16), nullable=True),
+    )
+
+    op.add_column(
+        "questions",
+        sa.Column("category_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_questions_category_id",
+        "questions",
+        "categories",
+        ["category_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+    categories_table = sa.table(
+        "categories",
+        sa.Column("id", sa.Integer()),
+        sa.Column("name", sa.String()),
+        sa.Column("slug", sa.String()),
+        sa.Column("description", sa.Text()),
+        sa.Column("icon", sa.String()),
+    )
+    op.bulk_insert(
+        categories_table,
+        [
+            {
+                "id": 1,
+                "name": "General",
+                "slug": "general",
+                "description": "Default category",
+                "icon": "📝",
+            }
+        ],
+    )
+
+    op.execute("UPDATE questions SET category_id = 1 WHERE category_id IS NULL")
+    op.alter_column("questions", "category_id", existing_type=sa.Integer(), nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_questions_category_id", "questions", type_="foreignkey")
+    op.drop_column("questions", "category_id")
+    op.drop_table("categories")

--- a/services/api/app/api/routes/categories.py
+++ b/services/api/app/api/routes/categories.py
@@ -1,0 +1,120 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db_session, require_admin
+from app.core.strings import slugify
+from app.models.category import Category
+from app.models.question import Question
+from app.schemas.category import CategoryCreate, CategoryOut, CategoryUpdate
+
+router = APIRouter(prefix="/categories", tags=["categories"])
+
+
+def _normalize_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+@router.get("/", response_model=List[CategoryOut])
+def list_categories(
+    db: Session = Depends(get_db_session),
+    _: None = Depends(require_admin),
+) -> List[CategoryOut]:
+    categories = list(db.scalars(select(Category).order_by(Category.name.asc())))
+    return [CategoryOut.model_validate(category) for category in categories]
+
+
+@router.post("/", response_model=CategoryOut, status_code=status.HTTP_201_CREATED)
+def create_category(
+    payload: CategoryCreate,
+    db: Session = Depends(get_db_session),
+    _: None = Depends(require_admin),
+) -> CategoryOut:
+    name = payload.name.strip()
+    slug = slugify(name)
+
+    existing = db.scalar(select(Category).where(Category.slug == slug))
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A category with this name already exists.",
+        )
+
+    category = Category(
+        name=name,
+        slug=slug,
+        description=_normalize_optional(payload.description),
+        icon=_normalize_optional(payload.icon),
+    )
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+    return CategoryOut.model_validate(category)
+
+
+@router.put("/{category_id}", response_model=CategoryOut)
+def update_category(
+    category_id: int,
+    payload: CategoryUpdate,
+    db: Session = Depends(get_db_session),
+    _: None = Depends(require_admin),
+) -> CategoryOut:
+    category = db.get(Category, category_id)
+    if category is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+
+    if payload.name is not None:
+        new_name = payload.name.strip()
+        if not new_name:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Name cannot be empty.",
+            )
+        new_slug = slugify(new_name)
+        duplicate = db.scalar(
+            select(Category).where(Category.slug == new_slug, Category.id != category.id)
+        )
+        if duplicate is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Another category with this name already exists.",
+            )
+        category.name = new_name
+        category.slug = new_slug
+
+    if payload.description is not None:
+        category.description = _normalize_optional(payload.description)
+    if payload.icon is not None:
+        category.icon = _normalize_optional(payload.icon)
+
+    db.commit()
+    db.refresh(category)
+    return CategoryOut.model_validate(category)
+
+
+@router.delete("/{category_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_category(
+    category_id: int,
+    db: Session = Depends(get_db_session),
+    _: None = Depends(require_admin),
+) -> None:
+    category = db.get(Category, category_id)
+    if category is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+
+    question_count = db.scalar(
+        select(func.count()).select_from(Question).where(Question.category_id == category.id)
+    )
+    if question_count and question_count > 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Remove or reassign questions before deleting this category.",
+        )
+
+    db.delete(category)
+    db.commit()

--- a/services/api/app/api/routes/practice.py
+++ b/services/api/app/api/routes/practice.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-import re
-from typing import Dict, Iterable, List, Optional, Sequence, Set
+from typing import Dict, List, Optional, Sequence, Set
+
+from typing import Dict, List, Optional, Sequence, Set
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import func, or_, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
 from app.api.deps import get_db_session
+from app.models.category import Category
 from app.models.question import Question
 from app.schemas.practice import (
     PracticeCategoryDetail,
@@ -17,22 +19,6 @@ from app.schemas.practice import (
 )
 
 router = APIRouter(prefix="/practice", tags=["practice"])
-
-
-def _normalized_subject(subject: Optional[str]) -> Optional[str]:
-    if subject is None:
-        return None
-    cleaned = subject.strip()
-    return cleaned or None
-
-
-def _subject_display_name(subject: Optional[str]) -> str:
-    return _normalized_subject(subject) or "General"
-
-
-def _slugify(value: str) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
-    return slug or "general"
 
 
 def _normalized_difficulty(value: Optional[str]) -> Optional[str]:
@@ -50,33 +36,6 @@ def _normalized_difficulty(value: Optional[str]) -> Optional[str]:
     return mapping.get(lowered, trimmed)
 
 
-def _collect_category_metadata(db: Session) -> Dict[str, Dict[str, object]]:
-    stmt = (
-        select(Question.subject, Question.difficulty, func.count(Question.id))
-        .where(Question.is_active.is_(True))
-        .group_by(Question.subject, Question.difficulty)
-    )
-    metadata: Dict[str, Dict[str, object]] = {}
-    for subject, difficulty, count in db.execute(stmt):
-        name = _subject_display_name(subject)
-        slug = _slugify(name)
-        entry = metadata.setdefault(
-            slug,
-            {
-                "name": name,
-                "total": 0,
-                "difficulties": set(),
-                "subjects": set(),
-            },
-        )
-        entry["total"] = int(entry["total"]) + int(count)
-        entry["subjects"].add(_normalized_subject(subject))
-        normalized_difficulty = _normalized_difficulty(difficulty)
-        if normalized_difficulty:
-            entry["difficulties"].add(normalized_difficulty)
-    return metadata
-
-
 def _difficulty_label(difficulties: Sequence[str]) -> str:
     unique = {_normalized_difficulty(difficulty) for difficulty in difficulties if difficulty}
     unique.discard(None)
@@ -91,39 +50,44 @@ def _difficulty_label(difficulties: Sequence[str]) -> str:
 def list_practice_categories(
     db: Session = Depends(get_db_session),
 ) -> List[PracticeCategorySummary]:
-    metadata = _collect_category_metadata(db)
+    categories = list(
+        db.scalars(
+            select(Category).order_by(Category.name.asc())
+        )
+    )
+
+    question_rows = db.execute(
+        select(Question.category_id, Question.difficulty)
+        .where(Question.is_active.is_(True))
+    ).all()
+
+    totals: Dict[int, int] = {}
+    difficulties_map: Dict[int, Set[str]] = {}
+
+    for category_id, difficulty in question_rows:
+        if category_id is None:
+            continue
+        totals[category_id] = totals.get(category_id, 0) + 1
+        normalized = _normalized_difficulty(difficulty)
+        if normalized:
+            difficulties_map.setdefault(category_id, set()).add(normalized)
+
     summaries: List[PracticeCategorySummary] = []
-    for slug, info in metadata.items():
-        difficulties = sorted(info["difficulties"])  # type: ignore[arg-type]
+    for category in categories:
+        difficulties = sorted(difficulties_map.get(category.id, set()))
         summaries.append(
             PracticeCategorySummary(
-                slug=slug,
-                name=info["name"],  # type: ignore[arg-type]
-                total_questions=info["total"],  # type: ignore[arg-type]
+                slug=category.slug,
+                name=category.name,
+                description=category.description,
+                icon=category.icon,
+                total_questions=totals.get(category.id, 0),
                 difficulty=_difficulty_label(difficulties),
                 difficulties=difficulties,
             )
         )
-    summaries.sort(key=lambda item: item.name.lower())
+
     return summaries
-
-
-def _subject_filters(subjects: Iterable[Optional[str]]):
-    normalized: Set[Optional[str]] = { _normalized_subject(subject) for subject in subjects }
-    string_subjects = sorted({subject for subject in normalized if subject})
-    include_empty = None in normalized
-
-    conditions = []
-    if string_subjects:
-        conditions.append(Question.subject.in_(string_subjects))
-    if include_empty:
-        conditions.append(Question.subject.is_(None))
-        conditions.append(Question.subject == "")
-    if not conditions:
-        return None
-    if len(conditions) == 1:
-        return conditions[0]
-    return or_(*conditions)
 
 
 @router.get("/categories/{slug}", response_model=PracticeCategoryDetail)
@@ -132,20 +96,15 @@ def get_practice_category(
     limit: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db_session),
 ) -> PracticeCategoryDetail:
-    metadata = _collect_category_metadata(db)
-    info = metadata.get(slug)
-    if info is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
-
-    filters = _subject_filters(info["subjects"])  # type: ignore[arg-type]
-    if filters is None:
+    category = db.scalar(select(Category).where(Category.slug == slug))
+    if category is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
 
     stmt = (
         select(Question)
         .options(selectinload(Question.options))
         .where(Question.is_active.is_(True))
-        .where(filters)
+        .where(Question.category_id == category.id)
         .order_by(Question.id.desc())
         .limit(limit)
     )
@@ -179,9 +138,11 @@ def get_practice_category(
         if normalized
     ]
     return PracticeCategoryDetail(
-        slug=slug,
-        name=info["name"],  # type: ignore[arg-type]
-        total_questions=info["total"],  # type: ignore[arg-type]
+        slug=category.slug,
+        name=category.name,
+        description=category.description,
+        icon=category.icon,
+        total_questions=len(questions),
         difficulty=_difficulty_label(difficulties),
         questions=questions_payload,
     )

--- a/services/api/app/core/strings.py
+++ b/services/api/app/core/strings.py
@@ -1,0 +1,8 @@
+import re
+
+
+def slugify(value: str) -> str:
+    """Return a URL-friendly slug for the provided value."""
+
+    normalized = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return normalized or "category"

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -4,6 +4,7 @@ from app.core.config import settings
 from app.api.routes.auth import router as auth_router
 from app.api.routes.attempts import router as attempts_router
 from app.api.routes.dashboard import router as dashboard_router
+from app.api.routes.categories import router as categories_router
 from app.api.routes.health import router as health_router
 from app.api.routes.practice import router as practice_router
 from app.api.routes.questions import router as questions_router
@@ -25,6 +26,7 @@ app.include_router(auth_router, prefix="/api")
 app.include_router(users_router, prefix="/api")
 app.include_router(quizzes_router, prefix="/api")
 app.include_router(questions_router, prefix="/api")
+app.include_router(categories_router, prefix="/api")
 app.include_router(practice_router, prefix="/api")
 app.include_router(attempts_router, prefix="/api")
 app.include_router(dashboard_router, prefix="/api")

--- a/services/api/app/models/__init__.py
+++ b/services/api/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.db.base import Base  # noqa: F401
 from app.models.attempt import Attempt, AttemptAnswer  # noqa: F401
+from app.models.category import Category  # noqa: F401
 from app.models.question import Option, Question, QuizQuestion  # noqa: F401
 from app.models.quiz import Quiz  # noqa: F401
 from app.models.user import User  # noqa: F401

--- a/services/api/app/models/category.py
+++ b/services/api/app/models/category.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class Category(Base):
+    __tablename__ = "categories"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
+    slug: Mapped[str] = mapped_column(String(160), unique=True, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text())
+    icon: Mapped[str | None] = mapped_column(String(16))
+
+    questions: Mapped[list["Question"]] = relationship(
+        "Question", back_populates="category"
+    )
+
+
+__all__ = ["Category"]

--- a/services/api/app/models/question.py
+++ b/services/api/app/models/question.py
@@ -17,6 +17,9 @@ class Question(Base):
     subject: Mapped[str | None] = mapped_column(String(100))
     difficulty: Mapped[str | None] = mapped_column(String(50))
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, server_default="true")
+    category_id: Mapped[int] = mapped_column(
+        ForeignKey("categories.id", ondelete="RESTRICT"), nullable=False
+    )
 
     options: Mapped[List["Option"]] = relationship(
         "Option", back_populates="question", cascade="all, delete-orphan", order_by="Option.id"
@@ -24,6 +27,7 @@ class Question(Base):
     quizzes: Mapped[List["QuizQuestion"]] = relationship(
         "QuizQuestion", back_populates="question", cascade="all, delete-orphan"
     )
+    category: Mapped["Category"] = relationship("Category", back_populates="questions")
 
 
 class Option(Base):

--- a/services/api/app/schemas/category.py
+++ b/services/api/app/schemas/category.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel, Field
+
+
+class CategoryBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=500)
+    icon: str | None = Field(default=None, max_length=16)
+
+
+class CategoryCreate(CategoryBase):
+    pass
+
+
+class CategoryUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=500)
+    icon: str | None = Field(default=None, max_length=16)
+
+
+class CategoryOut(CategoryBase):
+    id: int
+    slug: str
+
+    model_config = {"from_attributes": True}
+
+
+class CategorySummary(BaseModel):
+    id: int
+    name: str
+    slug: str
+
+    model_config = {"from_attributes": True}

--- a/services/api/app/schemas/practice.py
+++ b/services/api/app/schemas/practice.py
@@ -8,9 +8,12 @@ from pydantic import BaseModel
 class PracticeCategorySummary(BaseModel):
     slug: str
     name: str
+    description: Optional[str]
+    icon: Optional[str]
     total_questions: int
     difficulty: str
     difficulties: List[str]
+    quiz_id: Optional[int] = None
 
 
 class PracticeQuestionOption(BaseModel):
@@ -38,6 +41,8 @@ class PracticeQuestion(BaseModel):
 class PracticeCategoryDetail(BaseModel):
     slug: str
     name: str
+    description: Optional[str]
+    icon: Optional[str]
     total_questions: int
     difficulty: str
     questions: List[PracticeQuestion]

--- a/services/api/app/schemas/question.py
+++ b/services/api/app/schemas/question.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
+from app.schemas.category import CategorySummary
+
 
 class OptionBase(BaseModel):
     text: str = Field(..., min_length=1)
@@ -28,6 +30,7 @@ class QuestionBase(BaseModel):
     subject: Optional[str] = None
     difficulty: Optional[str] = None
     is_active: bool = True
+    category_id: int
 
 
 class QuestionCreate(QuestionBase):
@@ -41,10 +44,12 @@ class QuestionUpdate(BaseModel):
     difficulty: Optional[str] = None
     is_active: Optional[bool] = None
     options: Optional[List[OptionCreate]] = None
+    category_id: Optional[int] = None
 
 
 class QuestionOut(QuestionBase):
     id: int
+    category: CategorySummary
     options: List[OptionOut]
 
     model_config = {
@@ -59,6 +64,8 @@ class QuestionSummary(BaseModel):
     difficulty: Optional[str]
     is_active: bool
     option_count: int
+    category_id: int
+    category_name: str
 
     model_config = {
         "from_attributes": True,

--- a/services/api/tests/test_practice.py
+++ b/services/api/tests/test_practice.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from app.api.routes import practice as practice_routes  # noqa: E402
 from app.db.base import Base  # noqa: E402
+from app.models.category import Category  # noqa: E402
 from app.models.question import Option, Question  # noqa: E402
 
 
@@ -19,6 +20,17 @@ Base.metadata.create_all(bind=engine)
 def seed_questions(db: Session) -> None:
     db.query(Option).delete()
     db.query(Question).delete()
+    db.query(Category).delete()
+
+    category = Category(
+        name="General Knowledge",
+        slug="general-knowledge",
+        description="World geography, history, science, and current events",
+        icon="🌍",
+    )
+
+    db.add(category)
+    db.flush()
 
     general_question = Question(
         prompt="Capital of Nepal is Kathmandu.",
@@ -26,6 +38,7 @@ def seed_questions(db: Session) -> None:
         subject="General Knowledge",
         difficulty="Easy",
         is_active=True,
+        category_id=category.id,
     )
     mixed_question = Question(
         prompt="Select the odd number.",
@@ -33,6 +46,7 @@ def seed_questions(db: Session) -> None:
         subject="General Knowledge",
         difficulty="Medium",
         is_active=True,
+        category_id=category.id,
     )
 
     db.add_all([general_question, mixed_question])
@@ -63,6 +77,8 @@ def test_practice_categories_reflect_active_questions():
     general = next(category for category in categories if category.slug == "general-knowledge")
     assert general.total_questions == 2
     assert general.difficulty == "Mixed"
+    assert general.icon == "🌍"
+    assert general.description is not None
 
 
 def test_practice_category_detail_returns_questions():
@@ -73,6 +89,7 @@ def test_practice_category_detail_returns_questions():
     assert detail.name == "General Knowledge"
     assert detail.total_questions == 2
     assert len(detail.questions) == 2
+    assert detail.icon == "🌍"
     assert all(len(question.options) == 4 for question in detail.questions)
     assert any(option.is_correct for option in detail.questions[0].options)
 


### PR DESCRIPTION
## Summary
- introduce persistent categories with dedicated schemas, migrations, and admin CRUD endpoints
- require questions to reference categories and surface the associated metadata through admin and practice APIs
- refresh the admin and learner UIs to manage categories and display real category details instead of static placeholders

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e69b3d48d48324ac44fc456b23c961