### PR TITLE
Revamp analytics UI with dynamic data-driven dashboards

### DIFF
--- a/apps/web/src/pages/Home.vue
+++ b/apps/web/src/pages/Home.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 
+import { http } from '../api/http'
 import { useAuthStore } from '../stores/auth'
 
 const auth = useAuthStore()
@@ -10,49 +11,81 @@ const isAuthenticated = computed(() => auth.isAuthenticated)
 
 const primaryCta = computed(() =>
   isAuthenticated.value
-    ? { label: 'Go to Dashboard', to: { name: 'dashboard' } }
-    : { label: 'Start Practicing', to: { name: 'register' } },
+    ? { label: 'Go to Dashboard', to: { name: 'dashboard' as const } }
+    : { label: 'Start Practicing', to: { name: 'register' as const } },
 )
 
 const secondaryCta = computed(() =>
   isAuthenticated.value
-    ? { label: 'Browse Quizzes', to: { name: 'dashboard' } }
-    : { label: 'Login to Continue', to: { name: 'login' } },
+    ? { label: 'Browse Quizzes', to: { name: 'dashboard' as const } }
+    : { label: 'Login to Continue', to: { name: 'login' as const } },
 )
 
-const features = [
-  {
-    title: 'Comprehensive Question Bank',
-    description:
-      'Access thousands of carefully curated questions across multiple categories and difficulty levels.',
-    icon: 'book',
-  },
-  {
-    title: 'Mock Tests',
-    description:
-      'Take timed mock tests that simulate real exam conditions to build confidence and speed.',
-    icon: 'users',
-  },
-  {
-    title: 'Performance Tracking',
-    description:
-      'Monitor your progress with detailed analytics and identify areas for improvement.',
-    icon: 'trophy',
-  },
-  {
-    title: 'Detailed Results',
-    description:
-      'Get instant feedback with comprehensive result analysis and performance insights.',
-    icon: 'chart',
-  },
-]
+type PracticeCategorySummary = {
+  slug: string
+  name: string
+  description?: string | null
+  icon?: string | null
+  total_questions: number
+  difficulty: string
+}
 
-const highlights = [
-  { label: 'Students practicing', value: '10k+' },
-  { label: 'Mock tests hosted', value: '320+' },
-  { label: 'Average score boost', value: '18%' },
-  { label: 'Success stories', value: '2.3k+' },
-]
+type QuizSummary = {
+  id: number
+  title: string
+  description?: string | null
+  is_active: boolean
+  question_count: number
+}
+
+const loading = ref(true)
+const error = ref('')
+
+const stats = ref({
+  categories: 0,
+  questions: 0,
+  quizzes: 0,
+})
+
+const topCategories = ref<PracticeCategorySummary[]>([])
+const featuredQuizzes = ref<QuizSummary[]>([])
+
+const loadHomeData = async () => {
+  loading.value = true
+  error.value = ''
+  try {
+    const [categoriesResponse, quizzesResponse] = await Promise.all([
+      http.get<PracticeCategorySummary[]>('/practice/categories'),
+      http.get<QuizSummary[]>('/quizzes'),
+    ])
+
+    const categories = categoriesResponse.data
+    const quizzes = quizzesResponse.data.filter((quiz) => quiz.is_active)
+
+    stats.value = {
+      categories: categories.length,
+      questions: categories.reduce((total, item) => total + item.total_questions, 0),
+      quizzes: quizzes.length,
+    }
+
+    topCategories.value = [...categories]
+      .sort((a, b) => b.total_questions - a.total_questions)
+      .slice(0, 4)
+
+    featuredQuizzes.value = [...quizzes]
+      .sort((a, b) => b.question_count - a.question_count)
+      .slice(0, 3)
+  } catch (err) {
+    console.error(err)
+    error.value = 'We could not load the latest practice data. Please try again soon.'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadHomeData)
+
+const fallbackDescription = 'Sharpen your understanding with focused practice and clear explanations.'
 </script>
 
 <template>
@@ -93,12 +126,12 @@ const highlights = [
       <section class="bg-card py-20 px-4">
         <div class="container mx-auto grid max-w-6xl gap-12 lg:grid-cols-[3fr,2fr]">
           <div class="space-y-6 text-center lg:text-left">
+            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Nepal Loksewa prep</p>
             <h1 class="text-4xl font-bold leading-tight md:text-6xl">
-              Master Your Competitive Exams
+              Master your competitive exams with confidence
             </h1>
             <p class="text-lg text-muted-foreground">
-              Practice with thousands of questions, track your progress, and ace your competitive exams with our comprehensive
-              mock test platform.
+              Access curated question banks, full-length mock tests, and personalised insights so you can focus on the topics that matter most.
             </p>
             <div class="flex flex-col items-center justify-center gap-4 sm:flex-row lg:justify-start">
               <RouterLink
@@ -114,118 +147,176 @@ const highlights = [
                 {{ secondaryCta.label }}
               </RouterLink>
             </div>
+            <div class="grid gap-3 sm:grid-cols-3">
+              <article
+                v-for="stat in [
+                  { label: 'Practice categories', value: stats.categories },
+                  { label: 'Active quizzes', value: stats.quizzes },
+                  { label: 'Questions to explore', value: stats.questions },
+                ]"
+                :key="stat.label"
+                class="rounded-lg border border-border bg-background/80 p-5 text-left shadow-sm backdrop-blur"
+              >
+                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">{{ stat.label }}</p>
+                <p class="mt-2 text-2xl font-bold">{{ loading ? '…' : stat.value }}</p>
+              </article>
+            </div>
           </div>
 
-          <dl class="grid grid-cols-2 gap-4">
-            <div
-              v-for="highlight in highlights"
-              :key="highlight.label"
-              class="rounded-lg border border-border bg-background/80 p-6 text-center shadow-sm backdrop-blur"
-            >
-              <dt class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                {{ highlight.label }}
-              </dt>
-              <dd class="mt-3 text-3xl font-bold">
-                {{ highlight.value }}
-              </dd>
+          <div class="space-y-4">
+            <div v-if="loading" class="h-64 animate-pulse rounded-2xl bg-muted"></div>
+            <div v-else-if="error" class="rounded-2xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-800">
+              {{ error }}
             </div>
-          </dl>
+            <div v-else class="space-y-4">
+              <article class="rounded-2xl border border-border bg-background p-6 shadow-sm">
+                <h2 class="text-base font-semibold">Latest highlights</h2>
+                <p class="mt-2 text-sm text-muted-foreground">
+                  Stay on track with fresh practice sets and quizzes sourced from the Loksewa curriculum.
+                </p>
+                <ul class="mt-4 space-y-3 text-sm text-muted-foreground">
+                  <li>• {{ stats.categories }} categories curated for daily prep</li>
+                  <li>• {{ stats.questions }} questions with detailed explanations</li>
+                  <li>• {{ stats.quizzes }} mock tests ready to launch anytime</li>
+                </ul>
+              </article>
+              <article class="rounded-2xl border border-border bg-background p-6 shadow-sm">
+                <h2 class="text-base font-semibold">Quick start</h2>
+                <ul class="mt-3 space-y-2 text-sm text-muted-foreground">
+                  <li>
+                    <RouterLink :to="{ name: 'categories' }" class="text-secondary hover:underline">Browse categories</RouterLink>
+                    to target specific topics
+                  </li>
+                  <li>
+                    <RouterLink :to="{ name: 'dashboard' }" class="text-secondary hover:underline">Visit your dashboard</RouterLink>
+                    for personalised insights
+                  </li>
+                  <li>
+                    <RouterLink :to="{ name: 'home', hash: '#quizzes' }" class="text-secondary hover:underline">Launch a mock test</RouterLink>
+                    and track your progress instantly
+                  </li>
+                </ul>
+              </article>
+            </div>
+          </div>
         </div>
       </section>
 
-      <section class="py-16 px-4">
+      <section v-if="!loading" class="py-16 px-4">
         <div class="container mx-auto max-w-6xl">
-          <h2 class="text-3xl font-bold text-center">Why Choose QuizMaster?</h2>
-          <p class="mt-4 text-center text-muted-foreground">
-            Discover the tools that help thousands of aspirants study smarter every day.
-          </p>
-          <div class="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-            <article
-              v-for="feature in features"
-              :key="feature.title"
-              class="flex flex-col gap-4 rounded-lg border border-border bg-card p-6 text-left shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+          <header class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Plan your practice</p>
+              <h2 class="text-3xl font-bold">Top categories right now</h2>
+              <p class="mt-2 text-sm text-muted-foreground">
+                Choose a subject to unlock targeted practice sessions tailored to your goals.
+              </p>
+            </div>
+            <RouterLink
+              :to="{ name: 'categories' }"
+              class="inline-flex items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-semibold transition hover:bg-muted"
             >
-              <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-secondary/15 text-secondary">
-                <svg
-                  v-if="feature.icon === 'book'"
-                  class="h-7 w-7"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
+              View all categories
+            </RouterLink>
+          </header>
+
+          <div v-if="topCategories.length === 0" class="mt-10 rounded-2xl border border-border bg-background p-8 text-center text-sm text-muted-foreground">
+            Categories will appear here once they are created.
+          </div>
+          <div v-else class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+            <article
+              v-for="category in topCategories"
+              :key="category.slug"
+              class="flex flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+            >
+              <div class="space-y-1">
+                <p class="text-sm font-semibold uppercase tracking-[0.3em] text-muted-foreground">{{ category.difficulty }}</p>
+                <h3 class="text-xl font-semibold">{{ category.name }}</h3>
+              </div>
+              <p class="text-sm leading-6 text-muted-foreground">
+                {{ category.description?.trim() || fallbackDescription }}
+              </p>
+              <div class="mt-auto flex items-center justify-between text-sm">
+                <span class="text-muted-foreground">{{ category.total_questions }} questions</span>
+                <RouterLink
+                  :to="{ name: 'practice', params: { slug: category.slug } }"
+                  class="inline-flex items-center gap-1 text-secondary hover:underline"
                 >
-                  <path d="M3.5 5A2.5 2.5 0 0 1 6 2.5h6V19H6a2.5 2.5 0 0 0-2.5 2.5Z" />
-                  <path d="M20.5 5A2.5 2.5 0 0 0 18 2.5h-6V19h6a2.5 2.5 0 0 1 2.5 2.5Z" />
-                  <path d="M12 4v15" />
-                </svg>
-                <svg
-                  v-else-if="feature.icon === 'users'"
-                  class="h-7 w-7"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M17 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2" />
-                  <circle cx="9" cy="7" r="4" />
-                  <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
-                  <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-                </svg>
-                <svg
-                  v-else-if="feature.icon === 'trophy'"
-                  class="h-7 w-7"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M8 21h8" />
-                  <path d="M12 17a5 5 0 0 0 5-5V4H7v8a5 5 0 0 0 5 5Z" />
-                  <path d="M8 4V2h8v2" />
-                  <path d="M4 6h3v4a3 3 0 0 1-3-3Z" />
-                  <path d="M20 6h-3v4a3 3 0 0 0 3-3Z" />
-                </svg>
-                <svg
-                  v-else
-                  class="h-7 w-7"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M3 3v18" />
-                  <path d="M7 13v8" />
-                  <path d="M11 9v12" />
-                  <path d="M15 5v16" />
-                  <path d="M19 11v10" />
-                </svg>
-              </span>
-              <div>
-                <h3 class="text-lg font-semibold">{{ feature.title }}</h3>
-                <p class="mt-2 text-sm text-muted-foreground">{{ feature.description }}</p>
+                  Practice
+                  <span aria-hidden="true">→</span>
+                </RouterLink>
               </div>
             </article>
           </div>
         </div>
       </section>
-    </main>
 
-    <footer class="border-t border-border py-8 px-4">
-      <div class="container mx-auto text-center text-sm text-muted-foreground">
-        © 2024 QuizMaster. Built for competitive exam success.
-      </div>
-    </footer>
+      <section id="quizzes" class="bg-muted/40 py-16 px-4">
+        <div class="container mx-auto max-w-6xl">
+          <header class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Mock tests</p>
+              <h2 class="text-3xl font-bold">Featured quizzes</h2>
+              <p class="mt-2 text-sm text-muted-foreground">
+                Tackle full-length practice tests designed to mirror the Loksewa experience.
+              </p>
+            </div>
+            <RouterLink
+              :to="{ name: isAuthenticated ? 'dashboard' : 'register' }"
+              class="inline-flex items-center justify-center rounded-md bg-secondary px-4 py-2 text-sm font-semibold text-secondary-foreground shadow-sm transition hover:bg-secondary/90"
+            >
+              {{ isAuthenticated ? 'Open dashboard' : 'Create free account' }}
+            </RouterLink>
+          </header>
+
+          <div v-if="loading" class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            <div v-for="n in 3" :key="`quiz-skeleton-${n}`" class="h-48 animate-pulse rounded-2xl bg-card"></div>
+          </div>
+          <div v-else-if="featuredQuizzes.length === 0" class="mt-10 rounded-2xl border border-border bg-background p-8 text-center text-sm text-muted-foreground">
+            Publish your first quiz to see it featured here.
+          </div>
+          <div v-else class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            <article
+              v-for="quiz in featuredQuizzes"
+              :key="quiz.id"
+              class="flex flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+            >
+              <h3 class="text-xl font-semibold text-foreground">{{ quiz.title }}</h3>
+              <p class="text-sm text-muted-foreground">{{ quiz.description || 'Challenge yourself with a timed mock test.' }}</p>
+              <div class="mt-auto flex items-center justify-between text-sm text-muted-foreground">
+                <span>{{ quiz.question_count }} questions</span>
+                <RouterLink :to="{ name: 'quiz', params: { id: quiz.id } }" class="inline-flex items-center gap-1 text-secondary hover:underline">
+                  Start
+                  <span aria-hidden="true">→</span>
+                </RouterLink>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-16 px-4">
+        <div class="container mx-auto max-w-4xl rounded-3xl border border-border bg-card p-10 text-center shadow-sm">
+          <h2 class="text-3xl font-bold text-foreground">Ready to accelerate your preparation?</h2>
+          <p class="mt-4 text-sm text-muted-foreground">
+            Join thousands of aspirants who rely on QuizMaster for structured practice, real-time analytics, and exam-ready confidence.
+          </p>
+          <div class="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <RouterLink
+              :to="primaryCta.to"
+              class="inline-flex items-center justify-center rounded-md bg-secondary px-5 py-2.5 text-sm font-semibold text-secondary-foreground shadow-sm transition hover:bg-secondary/90"
+            >
+              {{ primaryCta.label }}
+            </RouterLink>
+            <RouterLink
+              :to="secondaryCta.to"
+              class="inline-flex items-center justify-center rounded-md border border-border px-5 py-2.5 text-sm font-semibold transition hover:bg-muted"
+            >
+              {{ secondaryCta.label }}
+            </RouterLink>
+          </div>
+        </div>
+      </section>
+    </main>
   </div>
 </template>

--- a/apps/web/src/pages/admin/Admin.vue
+++ b/apps/web/src/pages/admin/Admin.vue
@@ -1,33 +1,65 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
+
 import { http } from '../../api/http'
 
-interface QuizSummary {
+interface AdminTotals {
+  total_quizzes: number
+  active_quizzes: number
+  total_questions: number
+  inactive_questions: number
+  total_categories: number
+  total_users: number
+}
+
+interface AdminRecentQuiz {
   id: number
   title: string
   question_count: number
+  is_active: boolean
+  created_at: string
 }
 
-const quizzes = ref<QuizSummary[]>([])
+interface AdminCategorySnapshot {
+  id: number
+  name: string
+  question_count: number
+}
+
+interface AdminOverview {
+  totals: AdminTotals
+  recent_quizzes: AdminRecentQuiz[]
+  top_categories: AdminCategorySnapshot[]
+}
+
 const loading = ref(true)
 const error = ref('')
+const overview = ref<AdminOverview | null>(null)
 
-const totalQuestions = computed(() => quizzes.value.reduce((acc, quiz) => acc + quiz.question_count, 0))
+const totals = computed(() => overview.value?.totals)
 
-const load = async () => {
+const loadOverview = async () => {
+  loading.value = true
+  error.value = ''
   try {
-    const { data } = await http.get<QuizSummary[]>('/quizzes')
-    quizzes.value = data
+    const { data } = await http.get<AdminOverview>('/admin/overview')
+    overview.value = data
   } catch (err) {
-    error.value = 'Unable to load quizzes.'
     console.error(err)
+    error.value = 'Unable to load the admin overview. Please try again.'
   } finally {
     loading.value = false
   }
 }
 
-onMounted(load)
+onMounted(loadOverview)
+
+const quizHealth = computed(() => {
+  if (!totals.value) return 0
+  if (totals.value.total_quizzes === 0) return 0
+  return Math.round((totals.value.active_quizzes / totals.value.total_quizzes) * 100)
+})
 </script>
 
 <template>
@@ -40,7 +72,7 @@ onMounted(load)
         <div class="space-y-2">
           <h1 class="text-3xl font-semibold text-slate-900">QuizMaster control center</h1>
           <p class="max-w-2xl text-sm text-slate-500">
-            Oversee the entire quiz library, manage question quality, and keep the platform running smoothly for learners.
+            Oversee quiz quality, question coverage, and category balance in one place.
           </p>
         </div>
         <div class="flex flex-col gap-3 sm:flex-row">
@@ -60,30 +92,36 @@ onMounted(load)
       </div>
     </header>
 
-    <div class="grid gap-5 lg:grid-cols-4">
+    <div v-if="loading" class="grid gap-5 lg:grid-cols-4">
+      <div v-for="n in 4" :key="n" class="h-32 animate-pulse rounded-3xl bg-white/70"></div>
+    </div>
+
+    <p v-else-if="error" class="rounded-3xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-800">{{ error }}</p>
+
+    <div v-else-if="overview" class="grid gap-5 lg:grid-cols-4">
       <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
         <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Active quizzes</p>
-        <p class="mt-3 text-3xl font-semibold text-slate-900">{{ loading ? '…' : quizzes.length }}</p>
-        <p class="mt-2 text-xs text-slate-500">Curate balanced coverage across subjects.</p>
+        <p class="mt-3 text-3xl font-semibold text-slate-900">{{ totals?.active_quizzes }}</p>
+        <p class="text-xs text-slate-500">Out of {{ totals?.total_quizzes }} published quizzes</p>
       </article>
       <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
         <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Question bank</p>
-        <p class="mt-3 text-3xl font-semibold text-slate-900">{{ loading ? '…' : totalQuestions }}</p>
-        <p class="mt-2 text-xs text-slate-500">Ensure each quiz has sufficient depth.</p>
+        <p class="mt-3 text-3xl font-semibold text-slate-900">{{ totals?.total_questions }}</p>
+        <p class="text-xs text-slate-500">{{ totals?.inactive_questions }} awaiting review</p>
       </article>
       <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">System status</p>
-        <p class="mt-3 text-3xl font-semibold text-emerald-600">98%</p>
-        <p class="mt-2 text-xs text-slate-500">API uptime for the last 7 days.</p>
+        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Category coverage</p>
+        <p class="mt-3 text-3xl font-semibold text-slate-900">{{ totals?.total_categories }}</p>
+        <p class="text-xs text-slate-500">Categories currently available to learners</p>
       </article>
       <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Pending reviews</p>
-        <p class="mt-3 text-3xl font-semibold text-slate-900">3</p>
-        <p class="mt-2 text-xs text-slate-500">Questions awaiting validation.</p>
+        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Quiz health</p>
+        <p class="mt-3 text-3xl font-semibold text-slate-900">{{ quizHealth }}%</p>
+        <p class="text-xs text-slate-500">Share of active quizzes ready to launch</p>
       </article>
     </div>
 
-    <div class="grid gap-6 xl:grid-cols-[2fr,3fr]">
+    <div v-if="overview" class="grid gap-6 xl:grid-cols-[2fr,3fr]">
       <section class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
         <header class="flex items-center justify-between">
           <div>
@@ -92,7 +130,7 @@ onMounted(load)
           </div>
         </header>
         <p class="mt-4 text-sm text-slate-500">
-          Maintain high-quality content by regularly reviewing accuracy, difficulty balance, and relevancy to the latest LokSewa syllabus.
+          Keep your library fresh by reviewing inactive questions and balancing difficulty across categories.
         </p>
         <RouterLink
           :to="{ name: 'admin-questions' }"
@@ -105,22 +143,21 @@ onMounted(load)
       <section class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
         <header class="flex items-center justify-between">
           <div>
-            <h2 class="text-lg font-semibold text-slate-900">Quiz catalog</h2>
-            <p class="text-xs text-slate-500">Monitor quiz availability and coverage.</p>
+            <h2 class="text-lg font-semibold text-slate-900">Latest quizzes</h2>
+            <p class="text-xs text-slate-500">Monitor coverage and activate new content.</p>
           </div>
         </header>
-        <div class="mt-5 space-y-3 text-sm text-slate-700">
-          <p v-if="loading" class="animate-pulse text-slate-400">Loading quizzes…</p>
-          <p v-else-if="error" class="text-red-600">{{ error }}</p>
+        <div class="mt-5 space-y-3 text-sm">
+          <p v-if="overview.recent_quizzes.length === 0" class="text-slate-500">No quizzes yet. Add questions to get started.</p>
           <ul v-else class="space-y-2">
             <li
-              v-for="quiz in quizzes"
+              v-for="quiz in overview.recent_quizzes"
               :key="quiz.id"
               class="flex items-center justify-between rounded-2xl border border-slate-200 px-4 py-3"
             >
               <div>
                 <p class="font-semibold text-slate-900">{{ quiz.title }}</p>
-                <p class="text-xs text-slate-500">{{ quiz.question_count }} questions</p>
+                <p class="text-xs text-slate-500">{{ quiz.question_count }} questions · {{ quiz.is_active ? 'Active' : 'Inactive' }}</p>
               </div>
               <RouterLink
                 :to="{ name: 'quiz', params: { id: quiz.id } }"
@@ -130,11 +167,30 @@ onMounted(load)
               </RouterLink>
             </li>
           </ul>
-          <p v-if="!loading && !error && quizzes.length === 0" class="text-xs text-slate-500">
-            No quizzes yet. Add questions first, then create quizzes via the API.
-          </p>
         </div>
       </section>
     </div>
+
+    <section v-if="overview" class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header class="flex items-center justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-slate-900">Top categories</h2>
+          <p class="text-xs text-slate-500">Where learners spend most of their time.</p>
+        </div>
+      </header>
+      <div class="mt-6">
+        <p v-if="overview.top_categories.length === 0" class="text-sm text-slate-500">No categories yet. Create one to begin.</p>
+        <div v-else class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          <article
+            v-for="category in overview.top_categories"
+            :key="category.id"
+            class="rounded-2xl border border-slate-200 bg-slate-50 p-4"
+          >
+            <p class="text-sm font-semibold text-slate-900">{{ category.name }}</p>
+            <p class="text-xs text-slate-500">{{ category.question_count }} questions available</p>
+          </article>
+        </div>
+      </div>
+    </section>
   </section>
 </template>

--- a/services/api/app/api/routes/admin.py
+++ b/services/api/app/api/routes/admin.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db_session, require_admin
+from app.models.category import Category
+from app.models.question import Question, QuizQuestion
+from app.models.quiz import Quiz
+from app.models.user import User
+from app.schemas.admin import AdminCategorySnapshot, AdminOverview, AdminRecentQuiz, AdminTotals
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.get("/overview", response_model=AdminOverview)
+def get_admin_overview(
+    _: None = Depends(require_admin),
+    db: Session = Depends(get_db_session),
+) -> AdminOverview:
+    totals = AdminTotals(
+        total_quizzes=int(db.scalar(select(func.count()).select_from(Quiz)) or 0),
+        active_quizzes=int(
+            db.scalar(select(func.count()).select_from(Quiz).where(Quiz.is_active.is_(True))) or 0
+        ),
+        total_questions=int(db.scalar(select(func.count()).select_from(Question)) or 0),
+        inactive_questions=int(
+            db.scalar(select(func.count()).select_from(Question).where(Question.is_active.is_(False))) or 0
+        ),
+        total_categories=int(db.scalar(select(func.count()).select_from(Category)) or 0),
+        total_users=int(db.scalar(select(func.count()).select_from(User)) or 0),
+    )
+
+    recent_rows = db.execute(
+        select(
+            Quiz.id,
+            Quiz.title,
+            Quiz.is_active,
+            Quiz.created_at,
+            func.count(QuizQuestion.question_id).label("question_count"),
+        )
+        .join(QuizQuestion, QuizQuestion.quiz_id == Quiz.id, isouter=True)
+        .group_by(Quiz.id)
+        .order_by(Quiz.created_at.desc())
+        .limit(8)
+    ).all()
+
+    recent_quizzes: List[AdminRecentQuiz] = [
+        AdminRecentQuiz(
+            id=row.id,
+            title=row.title,
+            question_count=int(row.question_count or 0),
+            is_active=bool(row.is_active),
+            created_at=row.created_at,
+        )
+        for row in recent_rows
+    ]
+
+    top_category_rows = db.execute(
+        select(
+            Category.id,
+            Category.name,
+            func.count(Question.id).label("question_count"),
+        )
+        .join(Question, Question.category_id == Category.id, isouter=True)
+        .group_by(Category.id)
+        .order_by(func.count(Question.id).desc(), Category.name.asc())
+        .limit(6)
+    ).all()
+
+    top_categories = [
+        AdminCategorySnapshot(
+            id=row.id,
+            name=row.name,
+            question_count=int(row.question_count or 0),
+        )
+        for row in top_category_rows
+    ]
+
+    return AdminOverview(
+        totals=totals,
+        recent_quizzes=recent_quizzes,
+        top_categories=top_categories,
+    )

--- a/services/api/app/api/routes/analytics.py
+++ b/services/api/app/api/routes/analytics.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import case, func, select
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user, get_db_session
+from app.models.attempt import Attempt, AttemptAnswer
+from app.models.category import Category
+from app.models.question import Question
+from app.models.user import User
+from app.schemas.analytics import (
+    AnalyticsOverview,
+    CategoryPerformance,
+    OverallStats,
+    TimeAnalysis,
+    WeeklyProgressEntry,
+)
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+
+def _as_float(value: float | None) -> float:
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _calculate_streak(attempts: Iterable[Attempt]) -> int:
+    unique_dates = sorted({attempt.submitted_at.date() for attempt in attempts})
+    if not unique_dates:
+        return 0
+
+    streak = 1
+    for index in range(len(unique_dates) - 1, 0, -1):
+        gap = (unique_dates[index] - unique_dates[index - 1]).days
+        if gap == 1:
+            streak += 1
+        elif gap > 1:
+            break
+    return streak
+
+
+@router.get("/overview", response_model=AnalyticsOverview)
+def get_analytics_overview(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db_session),
+) -> AnalyticsOverview:
+    attempts: List[Attempt] = (
+        db.query(Attempt)
+        .filter(Attempt.user_id == current_user.id)
+        .order_by(Attempt.submitted_at.asc())
+        .all()
+    )
+
+    total_tests = len(attempts)
+    average_score = _as_float(sum(_as_float(attempt.score) for attempt in attempts) / total_tests) if total_tests else 0.0
+    total_time_spent = int(sum(attempt.duration_seconds or 0 for attempt in attempts))
+
+    window = min(5, total_tests) or 1
+    early_average = (
+        sum(_as_float(attempt.score) for attempt in attempts[:window]) / window
+        if attempts
+        else 0.0
+    )
+    recent_average = (
+        sum(_as_float(attempt.score) for attempt in attempts[-window:]) / window
+        if attempts
+        else 0.0
+    )
+    improvement_rate = round(recent_average - early_average, 2)
+
+    streak = _calculate_streak(attempts)
+
+    weekly_progress_map: Dict[datetime, Dict[str, float]] = defaultdict(lambda: {"tests": 0, "score_sum": 0.0})
+    for attempt in attempts:
+        date = attempt.submitted_at.astimezone(timezone.utc).date()
+        week_start = date - timedelta(days=date.weekday())
+        bucket = weekly_progress_map[datetime.combine(week_start, datetime.min.time(), tzinfo=timezone.utc)]
+        bucket["tests"] += 1
+        bucket["score_sum"] += _as_float(attempt.score)
+
+    weekly_progress = [
+        WeeklyProgressEntry(
+            label=bucket_date.strftime("Week of %d %b %Y"),
+            tests=int(payload["tests"]),
+            average_score=round(payload["score_sum"] / payload["tests"], 2) if payload["tests"] else 0.0,
+        )
+        for bucket_date, payload in sorted(weekly_progress_map.items())
+    ]
+
+    total_answered = sum(attempt.total_questions or 0 for attempt in attempts)
+    average_time_per_question = (
+        (total_time_spent / total_answered) if total_answered else 0.0
+    )
+    fastest_attempt = min((attempt.duration_seconds or 0 for attempt in attempts), default=0)
+    slowest_attempt = max((attempt.duration_seconds or 0 for attempt in attempts), default=0)
+    recommended_lower = max(average_time_per_question - 15, 5) if average_time_per_question else 0.0
+    recommended_upper = average_time_per_question + 15 if average_time_per_question else 0.0
+
+    time_analysis = None
+    if total_tests:
+        time_analysis = TimeAnalysis(
+            average_time_per_question_seconds=round(average_time_per_question, 2),
+            fastest_attempt_seconds=int(fastest_attempt),
+            slowest_attempt_seconds=int(slowest_attempt),
+            recommended_time_per_question_lower=round(recommended_lower, 2),
+            recommended_time_per_question_upper=round(recommended_upper, 2),
+        )
+
+    attempt_ids = [attempt.id for attempt in attempts]
+    category_performance: List[CategoryPerformance] = []
+    strengths: List[str] = []
+    weaknesses: List[str] = []
+
+    if attempt_ids:
+        category_rows = db.execute(
+            select(
+                Attempt.id.label("attempt_id"),
+                Attempt.submitted_at,
+                Category.name.label("category_name"),
+                func.count(AttemptAnswer.id).label("answered"),
+                func.sum(case((AttemptAnswer.is_correct.is_(True), 1), else_=0)).label("correct"),
+            )
+            .join(AttemptAnswer, AttemptAnswer.attempt_id == Attempt.id)
+            .join(Question, Question.id == AttemptAnswer.question_id)
+            .join(Category, Category.id == Question.category_id)
+            .where(Attempt.id.in_(attempt_ids))
+            .group_by(Attempt.id, Attempt.submitted_at, Category.id)
+            .order_by(Category.name, Attempt.submitted_at)
+        ).all()
+
+        category_history: Dict[str, List[tuple[datetime, float]]] = defaultdict(list)
+        for row in category_rows:
+            answered = row.answered or 0
+            if answered == 0:
+                continue
+            accuracy = (row.correct or 0) / answered * 100
+            category_history[row.category_name].append((row.submitted_at, accuracy))
+
+        for category_name, history in category_history.items():
+            history.sort(key=lambda item: item[0])
+            scores = [entry[1] for entry in history]
+            average = sum(scores) / len(scores)
+            best = max(scores)
+            improvement = scores[-1] - scores[0] if len(scores) > 1 else 0.0
+            category_performance.append(
+                CategoryPerformance(
+                    category=category_name,
+                    tests=len(history),
+                    average_score=round(average, 2),
+                    best_score=round(best, 2),
+                    improvement=round(improvement, 2),
+                )
+            )
+
+        category_performance.sort(key=lambda entry: entry.average_score, reverse=True)
+
+        if category_performance:
+            strengths = [entry.category for entry in category_performance if entry.average_score >= 75]
+            weaknesses = [entry.category for entry in category_performance if entry.average_score < 55]
+            strengths = strengths[:3]
+            weaknesses = weaknesses[:3]
+
+    overall = OverallStats(
+        total_tests=total_tests,
+        average_score=round(average_score, 2),
+        total_time_spent_seconds=total_time_spent,
+        improvement_rate=round(improvement_rate, 2),
+        streak=streak,
+    )
+
+    return AnalyticsOverview(
+        generated_at=datetime.now(timezone.utc),
+        overall_stats=overall,
+        category_performance=category_performance,
+        weekly_progress=weekly_progress,
+        time_analysis=time_analysis,
+        strengths=strengths,
+        weaknesses=weaknesses,
+    )

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
+from app.api.routes.admin import router as admin_router
+from app.api.routes.analytics import router as analytics_router
 from app.api.routes.auth import router as auth_router
 from app.api.routes.attempts import router as attempts_router
 from app.api.routes.dashboard import router as dashboard_router
@@ -30,3 +32,5 @@ app.include_router(categories_router, prefix="/api")
 app.include_router(practice_router, prefix="/api")
 app.include_router(attempts_router, prefix="/api")
 app.include_router(dashboard_router, prefix="/api")
+app.include_router(analytics_router, prefix="/api")
+app.include_router(admin_router, prefix="/api")

--- a/services/api/app/schemas/admin.py
+++ b/services/api/app/schemas/admin.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel
+
+
+class AdminTotals(BaseModel):
+    total_quizzes: int
+    active_quizzes: int
+    total_questions: int
+    inactive_questions: int
+    total_categories: int
+    total_users: int
+
+
+class AdminRecentQuiz(BaseModel):
+    id: int
+    title: str
+    question_count: int
+    is_active: bool
+    created_at: datetime
+
+
+class AdminCategorySnapshot(BaseModel):
+    id: int
+    name: str
+    question_count: int
+
+
+class AdminOverview(BaseModel):
+    totals: AdminTotals
+    recent_quizzes: List[AdminRecentQuiz]
+    top_categories: List[AdminCategorySnapshot]

--- a/services/api/app/schemas/analytics.py
+++ b/services/api/app/schemas/analytics.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class OverallStats(BaseModel):
+    total_tests: int
+    average_score: float
+    total_time_spent_seconds: int
+    improvement_rate: float
+    streak: int
+
+
+class CategoryPerformance(BaseModel):
+    category: str
+    tests: int
+    average_score: float
+    best_score: float
+    improvement: float
+
+
+class WeeklyProgressEntry(BaseModel):
+    label: str
+    tests: int
+    average_score: float
+
+
+class TimeAnalysis(BaseModel):
+    average_time_per_question_seconds: float
+    fastest_attempt_seconds: int
+    slowest_attempt_seconds: int
+    recommended_time_per_question_lower: float
+    recommended_time_per_question_upper: float
+
+
+class AnalyticsOverview(BaseModel):
+    generated_at: datetime
+    overall_stats: OverallStats
+    category_performance: List[CategoryPerformance]
+    weekly_progress: List[WeeklyProgressEntry]
+    time_analysis: Optional[TimeAnalysis]
+    strengths: List[str]
+    weaknesses: List[str]


### PR DESCRIPTION
## Summary
- add analytics and admin overview APIs to serve real usage insights
- redesign home, analytics, and admin pages to surface backend-driven data with polished UX
- connect frontend views to new endpoints and dynamic stats with modern loading/error states

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6a1d8e9808324afdcaf499d514658