### PR TITLE
feat: add multi-tenant foundations and notifications

### DIFF
--- a/services/api/alembic/versions/202410010900_phase1_multitenant.py
+++ b/services/api/alembic/versions/202410010900_phase1_multitenant.py
@@ -1,0 +1,220 @@
+"""Phase 1 multi-tenant foundations"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "202410010900"
+down_revision = "202409201200"
+branch_labels = None
+depends_on = None
+
+
+organization_status_enum = sa.Enum(
+    "active", "inactive", name="organization_status_enum", native_enum=False
+)
+user_role_enum = sa.Enum("superuser", "org_admin", "admin", "user", name="user_role", native_enum=False)
+user_status_enum = sa.Enum("active", "inactive", name="user_status", native_enum=False)
+org_membership_role = sa.Enum(
+    "org_admin", "instructor", "member", name="org_membership_role", native_enum=False
+)
+org_membership_status = sa.Enum(
+    "active", "invited", name="org_membership_status", native_enum=False
+)
+email_event_status = sa.Enum(
+    "queued", "sent", "failed", name="email_event_status", native_enum=False
+)
+app_config_scope = sa.Enum("global", "org", name="app_config_scope", native_enum=False)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    organization_status_enum.create(bind, checkfirst=True)
+    user_role_enum.create(bind, checkfirst=True)
+    user_status_enum.create(bind, checkfirst=True)
+    org_membership_role.create(bind, checkfirst=True)
+    org_membership_status.create(bind, checkfirst=True)
+    email_event_status.create(bind, checkfirst=True)
+    app_config_scope.create(bind, checkfirst=True)
+
+    op.create_table(
+        "organizations",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("slug", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("type", sa.String(length=50), nullable=True),
+        sa.Column("status", organization_status_enum, nullable=False, server_default="active"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "app_configs",
+        sa.Column("key", sa.String(length=255), primary_key=True),
+        sa.Column("value_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("scope", app_config_scope, nullable=False, server_default="global"),
+        sa.Column("organization_id", sa.Integer(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+    )
+
+    op.create_table(
+        "email_events",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("to_email", sa.String(length=255), nullable=False),
+        sa.Column("template", sa.String(length=128), nullable=False),
+        sa.Column("payload_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("status", email_event_status, nullable=False, server_default="queued"),
+        sa.Column("error_msg", sa.String(length=1024), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_index("ix_email_events_status_created", "email_events", ["status", "created_at"])
+
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("type", sa.String(length=64), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("body", sa.String(length=1024), nullable=False),
+        sa.Column("meta_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+
+    op.execute("CREATE INDEX ix_notifications_user_created ON notifications (user_id, created_at DESC)")
+    op.create_index("ix_notifications_user_read", "notifications", ["user_id", "read_at"])
+
+    op.create_table(
+        "enroll_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("organization_id", sa.Integer(), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("token_hash", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_by_user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "org_memberships",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("organization_id", sa.Integer(), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("org_role", org_membership_role, nullable=False, server_default="member"),
+        sa.Column("status", org_membership_status, nullable=False, server_default="active"),
+        sa.UniqueConstraint("organization_id", "user_id", name="uq_org_membership_org_user"),
+    )
+
+    op.create_table(
+        "user_profiles",
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("phone", sa.String(length=32), nullable=True),
+        sa.Column("student_id", sa.String(length=128), nullable=True, unique=True),
+        sa.Column("qr_code_uri", sa.String(length=512), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+
+    op.add_column("users", sa.Column("role", user_role_enum, nullable=False, server_default="user"))
+    op.add_column("users", sa.Column("organization_id", sa.Integer(), nullable=True))
+    op.add_column("users", sa.Column("status", user_status_enum, nullable=False, server_default="active"))
+    op.add_column(
+        "users",
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_users_org_status", "users", ["organization_id", "status"])
+    op.create_foreign_key(
+        "fk_users_organization_id",
+        "users",
+        "organizations",
+        ["organization_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.add_column("quizzes", sa.Column("organization_id", sa.Integer(), nullable=True))
+    op.create_index("ix_quizzes_org", "quizzes", ["organization_id"])
+    op.create_foreign_key(
+        "fk_quizzes_organization_id",
+        "quizzes",
+        "organizations",
+        ["organization_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.alter_column("attempts", "submitted_at", new_column_name="finished_at")
+    op.add_column("attempts", sa.Column("organization_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        "fk_attempts_organization_id",
+        "attempts",
+        "organizations",
+        ["organization_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.execute(
+        "CREATE INDEX ix_attempts_user_finished ON attempts (user_id, finished_at DESC)"
+    )
+    op.execute(
+        "CREATE INDEX ix_attempts_org_finished ON attempts (organization_id, finished_at DESC)"
+    )
+
+    op.add_column("questions", sa.Column("topic", sa.String(length=100), nullable=True))
+    op.add_column("questions", sa.Column("text_en", sa.Text(), nullable=True))
+    op.add_column("questions", sa.Column("text_ne", sa.Text(), nullable=True))
+    op.create_index(
+        "ix_questions_subject_topic_difficulty",
+        "questions",
+        ["subject", "topic", "difficulty"],
+    )
+    op.execute(
+        "CREATE INDEX ix_questions_fts ON questions USING gin (to_tsvector('simple', coalesce(text_en,'') || ' ' || coalesce(text_ne,'')))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_questions_fts")
+    op.drop_index("ix_questions_subject_topic_difficulty", table_name="questions")
+    op.drop_column("questions", "text_ne")
+    op.drop_column("questions", "text_en")
+    op.drop_column("questions", "topic")
+
+    op.execute("DROP INDEX IF EXISTS ix_attempts_org_finished")
+    op.execute("DROP INDEX IF EXISTS ix_attempts_user_finished")
+    op.drop_constraint("fk_attempts_organization_id", "attempts", type_="foreignkey")
+    op.drop_column("attempts", "organization_id")
+    op.alter_column("attempts", "finished_at", new_column_name="submitted_at")
+
+    op.drop_constraint("fk_quizzes_organization_id", "quizzes", type_="foreignkey")
+    op.drop_index("ix_quizzes_org", table_name="quizzes")
+    op.drop_column("quizzes", "organization_id")
+
+    op.drop_constraint("fk_users_organization_id", "users", type_="foreignkey")
+    op.drop_index("ix_users_org_status", table_name="users")
+    op.drop_column("users", "created_at")
+    op.drop_column("users", "status")
+    op.drop_column("users", "organization_id")
+    op.drop_column("users", "role")
+
+    op.drop_table("user_profiles")
+    op.drop_table("org_memberships")
+    op.drop_table("enroll_tokens")
+    op.drop_index("ix_notifications_user_read", table_name="notifications")
+    op.execute("DROP INDEX IF EXISTS ix_notifications_user_created")
+    op.drop_table("notifications")
+    op.drop_index("ix_email_events_status_created", table_name="email_events")
+    op.drop_table("email_events")
+    op.drop_table("app_configs")
+    op.drop_table("organizations")
+
+    organization_status_enum.drop(op.get_bind(), checkfirst=True)
+    user_role_enum.drop(op.get_bind(), checkfirst=True)
+    user_status_enum.drop(op.get_bind(), checkfirst=True)
+    org_membership_role.drop(op.get_bind(), checkfirst=True)
+    org_membership_status.drop(op.get_bind(), checkfirst=True)
+    email_event_status.drop(op.get_bind(), checkfirst=True)
+    app_config_scope.drop(op.get_bind(), checkfirst=True)

--- a/services/api/app/api/deps.py
+++ b/services/api/app/api/deps.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
-from app.core.security import decode_jwt_token
+from app.core.security import decode_token
 from app.db.session import get_db
 from app.models.user import User
 
@@ -14,29 +16,32 @@ def get_db_session(db: Session = Depends(get_db)) -> Session:
     return db
 
 
-def _resolve_user(
-    credentials: HTTPAuthorizationCredentials | None,
-    db: Session,
-) -> User:
+def get_current_token(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security_scheme),
+) -> dict:
     if credentials is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
     try:
-        user_id = int(decode_jwt_token(credentials.credentials))
+        return decode_token(credentials.credentials)
     except Exception:  # noqa: BLE001
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from None
 
-    user = db.get(User, user_id)
-    if user is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
-    return user
-
 
 def get_current_user(
-    credentials: HTTPAuthorizationCredentials | None = Depends(security_scheme),
+    token: dict = Depends(get_current_token),
     db: Session = Depends(get_db_session),
 ) -> User:
-    return _resolve_user(credentials, db)
+    try:
+        user_id = int(token["sub"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
+
+    user = db.get(User, user_id)
+    if not user or user.status != "active":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    setattr(user, "token_claims", token)
+    return user
 
 
 def get_current_user_optional(
@@ -45,10 +50,54 @@ def get_current_user_optional(
 ) -> User | None:
     if credentials is None:
         return None
-    return _resolve_user(credentials, db)
+    try:
+        token = decode_token(credentials.credentials)
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        user_id = int(token["sub"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    user = db.get(User, user_id)
+    if not user:
+        return None
+    setattr(user, "token_claims", token)
+    return user
 
 
-def require_admin(current_user: User = Depends(get_current_user)) -> User:
-    if current_user.role != "admin":
+def require_active_user(current_user: User = Depends(get_current_user)) -> User:
+    if current_user.status != "active":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Inactive account")
+    return current_user
+
+
+def require_superuser(current_user: User = Depends(require_active_user)) -> User:
+    if current_user.role != "superuser":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Superuser access required")
+    return current_user
+
+
+def require_admin(current_user: User = Depends(require_active_user)) -> User:
+    if current_user.role not in {"admin", "superuser"}:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
     return current_user
+
+
+def require_org_admin_or_superuser(current_user: User = Depends(require_active_user)) -> User:
+    if current_user.role not in {"org_admin", "superuser"}:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org admin access required")
+    return current_user
+
+
+def require_user(current_user: User = Depends(require_active_user)) -> User:
+    return current_user
+
+
+def get_current_org_id(token: dict = Depends(get_current_token)) -> int | None:
+    organization_id = token.get("organization_id")
+    if organization_id is None:
+        return None
+    try:
+        return int(organization_id)
+    except (TypeError, ValueError):
+        return None

--- a/services/api/app/api/routes/notifications.py
+++ b/services/api/app/api/routes/notifications.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.api.deps import get_current_user, get_db_session
+from app.models.user import User
+from app.schemas.notifications import NotificationListResponse, NotificationReadResponse
+from app.services.notification_service import NotificationService
+
+router = APIRouter(prefix="/notifications", tags=["notifications"])
+
+
+@router.get("", response_model=NotificationListResponse)
+def list_notifications(
+    unread: int | None = Query(default=None, ge=0, le=1),
+    limit: int = Query(default=20, ge=1, le=100),
+    cursor: datetime | None = Query(default=None),
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    service = NotificationService(db)
+    notifications, next_cursor = service.list_for_user(
+        current_user.id,
+        limit=limit,
+        cursor=cursor,
+        unread_only=bool(unread),
+    )
+    return NotificationListResponse.from_entities(notifications, next_cursor)
+
+
+@router.post("/{notification_id}/read", response_model=NotificationReadResponse)
+def mark_notification_read(
+    notification_id: int,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    service = NotificationService(db)
+    success = service.mark_read(notification_id, current_user.id)
+    if not success:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification not found")
+    db.commit()
+    return NotificationReadResponse(marked=True)
+
+
+@router.post("/read-all", response_model=NotificationReadResponse)
+def mark_all_notifications_read(
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    service = NotificationService(db)
+    updated = service.mark_all_read(current_user.id)
+    db.commit()
+    return NotificationReadResponse(marked=bool(updated), count=updated)

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -1,19 +1,54 @@
+from collections.abc import Sequence
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from typing import List
+
 
 class Settings(BaseSettings):
-    database_url: str = "postgresql+psycopg://quiz:quiz@localhost:5432/quizhub"
-    jwt_secret: str = "dev-secret"
-    jwt_alg: str = "HS256"
-    access_token_expire_minutes: int = 30
-    refresh_token_expire_days: int = 14
+    database_url: str = Field(
+        default="postgresql+psycopg://quiz:quiz@localhost:5432/quizhub",
+        description="SQLAlchemy compatible database URL",
+    )
+    database_pool_size: int = Field(default=15, ge=5, le=50)
+    database_max_overflow: int = Field(default=10, ge=0, le=50)
+    redis_url: str | None = Field(default=None, description="Optional Redis connection URL")
+
+    jwt_secret: str = Field(default="dev-secret")
+    jwt_refresh_secret: str | None = None
+    jwt_alg: str = Field(default="HS256")
+    access_token_expire_minutes: int = Field(default=30, ge=5, le=120)
+    refresh_token_expire_minutes: int = Field(default=60 * 24 * 14, ge=60)
 
     backend_cors_origins: str = "http://localhost:5173"
+
+    smtp_host: str | None = None
+    smtp_port: int | None = None
+    smtp_username: str | None = None
+    smtp_password: str | None = None
+    smtp_tls_ssl: bool = True
+    mail_from_name: str | None = None
+    mail_from_email: str | None = None
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False)
 
     @property
-    def cors_origins(self) -> List[str]:
+    def cors_origins(self) -> list[str]:
         return [o.strip() for o in self.backend_cors_origins.split(",") if o.strip()]
+
+    @property
+    def effective_jwt_refresh_secret(self) -> str:
+        return self.jwt_refresh_secret or self.jwt_secret
+
+    @property
+    def mail_settings(self) -> dict[str, str | int | bool | None]:
+        return {
+            "host": self.smtp_host,
+            "port": self.smtp_port,
+            "username": self.smtp_username,
+            "password": self.smtp_password,
+            "tls_ssl": self.smtp_tls_ssl,
+            "from_name": self.mail_from_name,
+            "from_email": self.mail_from_email,
+        }
+
 
 settings = Settings()

--- a/services/api/app/core/security.py
+++ b/services/api/app/core/security.py
@@ -1,46 +1,67 @@
-from datetime import datetime, timedelta
-from typing import Optional
+from __future__ import annotations
 
-import bcrypt
-import hashlib
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict
+
 import jwt
+from passlib.context import CryptContext
 
 from app.core.config import settings
 
 
-def _normalized_password(password: str) -> bytes:
-    """Ensure consistent hashing input and avoid bcrypt's 72 byte limit."""
-    digest = hashlib.sha256(password.encode("utf-8")).hexdigest()
-    return digest.encode("ascii")
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+_BCRYPT_LIMIT = 72
+
+
+def _truncate_password(password: str) -> str:
+    password_bytes = password.encode("utf-8")
+    if len(password_bytes) <= _BCRYPT_LIMIT:
+        return password
+    return password_bytes[:_BCRYPT_LIMIT].decode("utf-8", errors="ignore")
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    hashed_bytes = hashed_password.encode("utf-8")
-
-    try:
-        if bcrypt.checkpw(_normalized_password(plain_password), hashed_bytes):
-            return True
-    except ValueError:
-        return False
-
-    try:
-        return bcrypt.checkpw(plain_password.encode("utf-8"), hashed_bytes)
-    except ValueError:
-        return False
+    plain_password = _truncate_password(plain_password)
+    return pwd_context.verify(plain_password, hashed_password)
 
 
 def get_password_hash(password: str) -> str:
-    return bcrypt.hashpw(_normalized_password(password), bcrypt.gensalt()).decode("ascii")
+    password = _truncate_password(password)
+    return pwd_context.hash(password)
 
-def create_jwt_token(subject: str, expires_delta: Optional[timedelta] = None) -> str:
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=settings.access_token_expire_minutes))
-    to_encode = {"sub": subject, "exp": expire}
+
+def _build_claims(subject: str, *, role: str, organization_id: int | None) -> Dict[str, Any]:
+    claims: Dict[str, Any] = {"sub": subject, "role": role}
+    if organization_id is not None:
+        claims["organization_id"] = organization_id
+    return claims
+
+
+def create_access_token(*, subject: str, role: str, organization_id: int | None) -> str:
+    expires_delta = timedelta(minutes=settings.access_token_expire_minutes)
+    expire = datetime.now(timezone.utc) + expires_delta
+    to_encode = _build_claims(subject, role=role, organization_id=organization_id)
+    to_encode["exp"] = expire
+    to_encode["type"] = "access"
     return jwt.encode(to_encode, settings.jwt_secret, algorithm=settings.jwt_alg)
 
 
-def decode_jwt_token(token: str) -> str:
-    payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_alg])
-    subject = payload.get("sub")
-    if subject is None:
+def create_refresh_token(*, subject: str, role: str, organization_id: int | None) -> str:
+    expires_delta = timedelta(minutes=settings.refresh_token_expire_minutes)
+    expire = datetime.now(timezone.utc) + expires_delta
+    to_encode = _build_claims(subject, role=role, organization_id=organization_id)
+    to_encode["exp"] = expire
+    to_encode["type"] = "refresh"
+    return jwt.encode(to_encode, settings.effective_jwt_refresh_secret, algorithm=settings.jwt_alg)
+
+
+def decode_token(token: str, *, refresh: bool = False) -> Dict[str, Any]:
+    secret = settings.effective_jwt_refresh_secret if refresh else settings.jwt_secret
+    payload = jwt.decode(token, secret, algorithms=[settings.jwt_alg])
+    if payload.get("sub") is None:
         raise ValueError("Token missing subject")
-    return subject
+    token_type = payload.get("type")
+    expected = "refresh" if refresh else "access"
+    if token_type != expected:
+        raise ValueError("Invalid token type")
+    return payload

--- a/services/api/app/db/session.py
+++ b/services/api/app/db/session.py
@@ -1,9 +1,15 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
 from app.core.config import settings
 
-engine = create_engine(settings.database_url, pool_pre_ping=True)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+engine = create_engine(
+    settings.database_url,
+    pool_pre_ping=True,
+    pool_size=settings.database_pool_size,
+    max_overflow=settings.database_max_overflow,
+)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
 
 def get_db():
     db = SessionLocal()

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -13,6 +13,7 @@ from app.api.routes.practice import router as practice_router
 from app.api.routes.questions import router as questions_router
 from app.api.routes.quizzes import router as quizzes_router
 from app.api.routes.users import router as users_router
+from app.api.routes.notifications import router as notifications_router
 
 app = FastAPI(title="Loksewa Quiz Hub API", version="0.1.0")
 
@@ -36,3 +37,4 @@ app.include_router(dashboard_router, prefix="/api")
 app.include_router(analytics_router, prefix="/api")
 app.include_router(admin_router, prefix="/api")
 app.include_router(bookmarks_router, prefix="/api")
+app.include_router(notifications_router, prefix="/api")

--- a/services/api/app/models/__init__.py
+++ b/services/api/app/models/__init__.py
@@ -4,4 +4,13 @@ from app.models.bookmark import Bookmark  # noqa: F401
 from app.models.category import Category  # noqa: F401
 from app.models.question import Option, Question, QuizQuestion  # noqa: F401
 from app.models.quiz import Quiz  # noqa: F401
+from app.models.organization import (  # noqa: F401
+    AppConfig,
+    EmailEvent,
+    EnrollToken,
+    Notification,
+    OrgMembership,
+    Organization,
+    UserProfile,
+)
 from app.models.user import User  # noqa: F401

--- a/services/api/app/models/attempt.py
+++ b/services/api/app/models/attempt.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Numeric
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, Numeric, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -11,19 +11,35 @@ from app.db.base import Base
 
 class Attempt(Base):
     __tablename__ = "attempts"
+    __table_args__ = (
+        Index("ix_attempts_user_finished", "user_id", text("finished_at DESC")),
+        Index("ix_attempts_org_finished", "organization_id", text("finished_at DESC")),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     quiz_id: Mapped[int] = mapped_column(ForeignKey("quizzes.id", ondelete="CASCADE"), nullable=False)
     started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    submitted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    finished_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     duration_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
     total_questions: Mapped[int] = mapped_column(Integer, nullable=False)
     correct_answers: Mapped[int] = mapped_column(Integer, nullable=False)
     score: Mapped[float] = mapped_column(Numeric(5, 2), nullable=False)
+    organization_id: Mapped[int | None] = mapped_column(
+        ForeignKey("organizations.id", ondelete="SET NULL"), nullable=True
+    )
 
     quiz: Mapped["Quiz"] = relationship("Quiz", back_populates="attempts")
     user: Mapped["User"] = relationship("User", back_populates="attempts")
+    organization: Mapped["Organization" | None] = relationship("Organization")
+
+    @property
+    def submitted_at(self) -> datetime:
+        return self.finished_at
+
+    @submitted_at.setter
+    def submitted_at(self, value: datetime) -> None:
+        self.finished_at = value
     answers: Mapped[List["AttemptAnswer"]] = relationship(
         "AttemptAnswer",
         back_populates="attempt",

--- a/services/api/app/models/organization.py
+++ b/services/api/app/models/organization.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Index, String, UniqueConstraint, func, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    slug: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    status: Mapped[str] = mapped_column(
+        Enum("active", "inactive", name="organization_status_enum", native_enum=False),
+        nullable=False,
+        default="active",
+        server_default="active",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    users: Mapped[List["User"]] = relationship("User", back_populates="organization")
+    memberships: Mapped[List["OrgMembership"]] = relationship(
+        "OrgMembership", back_populates="organization", cascade="all, delete-orphan"
+    )
+    enroll_tokens: Mapped[List["EnrollToken"]] = relationship(
+        "EnrollToken", back_populates="organization", cascade="all, delete-orphan"
+    )
+    configs: Mapped[List["AppConfig"]] = relationship(
+        "AppConfig", back_populates="organization", cascade="all, delete-orphan"
+    )
+
+
+class UserProfile(Base):
+    __tablename__ = "user_profiles"
+
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    student_id: Mapped[str | None] = mapped_column(String(128), unique=True, nullable=True)
+    qr_code_uri: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    user: Mapped["User"] = relationship("User", back_populates="profile")
+
+
+class OrgMembership(Base):
+    __tablename__ = "org_memberships"
+    __table_args__ = (
+        UniqueConstraint("organization_id", "user_id", name="uq_org_membership_org_user"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    organization_id: Mapped[int] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    org_role: Mapped[str] = mapped_column(
+        Enum("org_admin", "instructor", "member", name="org_membership_role", native_enum=False),
+        nullable=False,
+        default="member",
+        server_default="member",
+    )
+    status: Mapped[str] = mapped_column(
+        Enum("active", "invited", name="org_membership_status", native_enum=False),
+        nullable=False,
+        default="active",
+        server_default="active",
+    )
+
+    organization: Mapped[Organization] = relationship("Organization", back_populates="memberships")
+    user: Mapped["User"] = relationship("User", back_populates="memberships")
+
+
+class EnrollToken(Base):
+    __tablename__ = "enroll_tokens"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    organization_id: Mapped[int] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    token_hash: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    used_by_user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    organization: Mapped[Organization] = relationship("Organization", back_populates="enroll_tokens")
+    used_by: Mapped["User" | None] = relationship("User", foreign_keys=[used_by_user_id])
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+    __table_args__ = (
+        Index("ix_notifications_user_created", "user_id", text("created_at DESC")),
+        Index("ix_notifications_user_read", "user_id", "read_at"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    type: Mapped[str] = mapped_column(String(64), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str] = mapped_column(String(1024), nullable=False)
+    meta_json: Mapped[dict | None] = mapped_column(JSONB(astext_type=String()), nullable=True)
+    read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    user: Mapped["User"] = relationship("User", back_populates="notifications")
+
+
+class EmailEvent(Base):
+    __tablename__ = "email_events"
+    __table_args__ = (
+        Index("ix_email_events_status_created", "status", "created_at"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    to_email: Mapped[str] = mapped_column(String(255), nullable=False)
+    template: Mapped[str] = mapped_column(String(128), nullable=False)
+    payload_json: Mapped[dict | None] = mapped_column(JSONB(astext_type=String()), nullable=True)
+    status: Mapped[str] = mapped_column(
+        Enum("queued", "sent", "failed", name="email_event_status", native_enum=False),
+        nullable=False,
+        default="queued",
+        server_default="queued",
+    )
+    error_msg: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class AppConfig(Base):
+    __tablename__ = "app_configs"
+
+    key: Mapped[str] = mapped_column(String(255), primary_key=True)
+    value_json: Mapped[dict | None] = mapped_column(JSONB(astext_type=String()), nullable=True)
+    scope: Mapped[str] = mapped_column(
+        Enum("global", "org", name="app_config_scope", native_enum=False),
+        nullable=False,
+        default="global",
+        server_default="global",
+    )
+    organization_id: Mapped[int | None] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"), nullable=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    organization: Mapped[Organization | None] = relationship("Organization", back_populates="configs")
+
+
+__all__ = [
+    "Organization",
+    "UserProfile",
+    "OrgMembership",
+    "EnrollToken",
+    "Notification",
+    "EmailEvent",
+    "AppConfig",
+]

--- a/services/api/app/models/question.py
+++ b/services/api/app/models/question.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List
 
-from sqlalchemy import Boolean, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, ForeignKey, Index, Integer, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -10,12 +10,23 @@ from app.db.base import Base
 
 class Question(Base):
     __tablename__ = "questions"
+    __table_args__ = (
+        Index("ix_questions_subject_topic_difficulty", "subject", "topic", "difficulty"),
+        Index(
+            "ix_questions_fts",
+            text("to_tsvector('simple', coalesce(text_en,'') || ' ' || coalesce(text_ne,''))"),
+            postgresql_using="gin",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     prompt: Mapped[str] = mapped_column(Text(), nullable=False)
     explanation: Mapped[str | None] = mapped_column(Text())
     subject: Mapped[str | None] = mapped_column(String(100))
+    topic: Mapped[str | None] = mapped_column(String(100))
     difficulty: Mapped[str | None] = mapped_column(String(50))
+    text_en: Mapped[str | None] = mapped_column(Text())
+    text_ne: Mapped[str | None] = mapped_column(Text())
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, server_default="true")
     category_id: Mapped[int] = mapped_column(
         ForeignKey("categories.id", ondelete="RESTRICT"), nullable=False

--- a/services/api/app/models/quiz.py
+++ b/services/api/app/models/quiz.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List
 
-from sqlalchemy import Boolean, DateTime, String, Text, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -11,6 +11,9 @@ from app.db.base import Base
 
 class Quiz(Base):
     __tablename__ = "quizzes"
+    __table_args__ = (
+        Index("ix_quizzes_org", "organization_id"),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     title: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
@@ -18,6 +21,9 @@ class Quiz(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, server_default="true")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    organization_id: Mapped[int | None] = mapped_column(
+        ForeignKey("organizations.id", ondelete="SET NULL"), nullable=True
     )
 
     questions: Mapped[List["QuizQuestion"]] = relationship(
@@ -27,6 +33,7 @@ class Quiz(Base):
         order_by="QuizQuestion.position",
     )
     attempts: Mapped[List["Attempt"]] = relationship("Attempt", back_populates="quiz")
+    organization: Mapped["Organization" | None] = relationship("Organization")
 
 
 __all__ = ["Quiz"]

--- a/services/api/app/models/user.py
+++ b/services/api/app/models/user.py
@@ -1,16 +1,55 @@
+from __future__ import annotations
+
+from datetime import datetime
 from typing import List
 
-from sqlalchemy import String
+from sqlalchemy import DateTime, Enum, ForeignKey, Index, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+
 from app.db.base import Base
+
 
 class User(Base):
     __tablename__ = "users"
-    id: Mapped[int] = mapped_column(primary_key=True, index=True)
-    email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    __table_args__ = (
+        Index("ix_users_org_status", "organization_id", "status"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
-    role: Mapped[str] = mapped_column(String(50), default="user")
-    attempts: Mapped[List["Attempt"]] = relationship("Attempt", back_populates="user", cascade="all, delete-orphan")
+    role: Mapped[str] = mapped_column(
+        Enum("superuser", "org_admin", "admin", "user", name="user_role", native_enum=False),
+        nullable=False,
+        default="user",
+        server_default="user",
+    )
+    organization_id: Mapped[int | None] = mapped_column(
+        ForeignKey("organizations.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    status: Mapped[str] = mapped_column(
+        Enum("active", "inactive", name="user_status", native_enum=False),
+        nullable=False,
+        default="active",
+        server_default="active",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    organization: Mapped["Organization" | None] = relationship("Organization", back_populates="users")
+    profile: Mapped["UserProfile" | None] = relationship(
+        "UserProfile", back_populates="user", cascade="all, delete-orphan", uselist=False
+    )
+    memberships: Mapped[List["OrgMembership"]] = relationship(
+        "OrgMembership", back_populates="user", cascade="all, delete-orphan"
+    )
+    notifications: Mapped[List["Notification"]] = relationship(
+        "Notification", back_populates="user", cascade="all, delete-orphan"
+    )
+    attempts: Mapped[List["Attempt"]] = relationship(
+        "Attempt", back_populates="user", cascade="all, delete-orphan"
+    )
     bookmarks: Mapped[List["Bookmark"]] = relationship(
         "Bookmark", back_populates="user", cascade="all, delete-orphan"
     )

--- a/services/api/app/schemas/attempt.py
+++ b/services/api/app/schemas/attempt.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Optional
 
+from datetime import datetime
+from typing import List, Optional
+
 from pydantic import BaseModel, Field
 
 

--- a/services/api/app/schemas/notifications.py
+++ b/services/api/app/schemas/notifications.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from app.models.organization import Notification
+
+
+class NotificationItem(BaseModel):
+    id: int
+    type: str
+    title: str
+    body: str
+    meta: dict | None = Field(default=None)
+    read_at: Optional[datetime]
+    created_at: datetime
+
+    @classmethod
+    def from_entity(cls, notification: Notification) -> "NotificationItem":
+        return cls(
+            id=notification.id,
+            type=notification.type,
+            title=notification.title,
+            body=notification.body,
+            meta=notification.meta_json,
+            read_at=notification.read_at,
+            created_at=notification.created_at,
+        )
+
+
+class NotificationListResponse(BaseModel):
+    items: List[NotificationItem]
+    next_cursor: Optional[datetime] = None
+
+    @classmethod
+    def from_entities(
+        cls, notifications: List[Notification], next_cursor: datetime | None
+    ) -> "NotificationListResponse":
+        return cls(
+            items=[NotificationItem.from_entity(notification) for notification in notifications],
+            next_cursor=next_cursor,
+        )
+
+
+class NotificationReadResponse(BaseModel):
+    marked: bool
+    count: int | None = None

--- a/services/api/app/services/__init__.py
+++ b/services/api/app/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer modules."""
+
+from .notification_service import NotificationService, get_notification_service
+
+__all__ = ["NotificationService", "get_notification_service"]

--- a/services/api/app/services/notification_service.py
+++ b/services/api/app/services/notification_service.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.organization import Notification
+
+
+class NotificationService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(
+        self,
+        *,
+        user_id: int,
+        type: str,
+        title: str,
+        body: str,
+        meta: dict | None = None,
+    ) -> Notification:
+        notification = Notification(
+            user_id=user_id,
+            type=type,
+            title=title,
+            body=body,
+            meta_json=meta or {},
+        )
+        self.db.add(notification)
+        self.db.flush()
+        return notification
+
+    def list_for_user(
+        self,
+        user_id: int,
+        *,
+        limit: int = 20,
+        cursor: datetime | None = None,
+        unread_only: bool = False,
+    ) -> tuple[List[Notification], datetime | None]:
+        limit = max(1, min(limit, 100))
+        stmt = select(Notification).where(Notification.user_id == user_id)
+        if unread_only:
+            stmt = stmt.where(Notification.read_at.is_(None))
+        if cursor is not None:
+            stmt = stmt.where(Notification.created_at < cursor)
+        stmt = stmt.order_by(Notification.created_at.desc()).limit(limit + 1)
+        rows = self.db.scalars(stmt).all()
+        next_cursor = None
+        if len(rows) > limit:
+            next_cursor = rows[-1].created_at
+            rows = rows[:limit]
+        return rows, next_cursor
+
+    def mark_read(self, notification_id: int, user_id: int) -> bool:
+        stmt = (
+            select(Notification)
+            .where(Notification.id == notification_id)
+            .where(Notification.user_id == user_id)
+            .limit(1)
+        )
+        notification = self.db.scalar(stmt)
+        if not notification:
+            return False
+        if notification.read_at is None:
+            notification.read_at = datetime.now(timezone.utc)
+            self.db.add(notification)
+        return True
+
+    def mark_all_read(self, user_id: int) -> int:
+        stmt = (
+            select(Notification)
+            .where(Notification.user_id == user_id)
+            .where(Notification.read_at.is_(None))
+        )
+        notifications = self.db.scalars(stmt).all()
+        updated = 0
+        now = datetime.now(timezone.utc)
+        for notification in notifications:
+            notification.read_at = now
+            updated += 1
+        return updated
+
+
+def get_notification_service(db: Session) -> NotificationService:
+    return NotificationService(db)

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -13,9 +13,11 @@ dependencies = [
   "pydantic-settings==2.*",
   "python-multipart==0.0.*",
   "bcrypt==4.0.1",
+  "passlib[bcrypt]==1.7.*",
   "email-validator==2.*",
   "python-dotenv==1.*",
   "PyJWT==2.9.*",
+  "jinja2==3.1.*",
 ]
 
 [tool.ruff]

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -7,6 +7,8 @@ pydantic==2.*
 pydantic-settings==2.*
 python-multipart==0.0.*
 bcrypt==4.0.1
+passlib[bcrypt]==1.7.*
 email-validator==2.*
 python-dotenv==1.*
 PyJWT==2.9.*
+jinja2==3.1.*


### PR DESCRIPTION
## Summary
- add multi-tenant schema changes for organizations, notifications, email events, and scoped indexes
- extend SQLAlchemy models, security configuration, and settings to support roles, org scoping, and richer question metadata
- introduce notification service and API endpoints for listing and marking notifications

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e775fccfa4832497f340e70b882f50