### PR TITLE
Add admin bulk import workflow for quizzes and questions

### DIFF
--- a/apps/web/src/pages/admin/Admin.vue
+++ b/apps/web/src/pages/admin/Admin.vue
@@ -87,6 +87,12 @@ const quizHealth = computed(() => {
         </div>
         <div class="flex flex-col gap-3 sm:flex-row">
           <RouterLink
+            :to="{ name: 'admin-bulk-import' }"
+            class="inline-flex items-center justify-center rounded-full border border-slate-200 px-6 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+          >
+            Bulk import
+          </RouterLink>
+          <RouterLink
             :to="{ name: 'admin-categories' }"
             class="inline-flex items-center justify-center rounded-full border border-slate-200 px-6 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
           >

--- a/apps/web/src/pages/admin/BulkImport.vue
+++ b/apps/web/src/pages/admin/BulkImport.vue
@@ -1,0 +1,577 @@
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue'
+import { http } from '../../api/http'
+
+interface PreviewCategory {
+  source_row: number | null
+  name: string
+  description: string | null
+  icon: string | null
+  slug: string
+  action: 'create' | 'update'
+  errors: string[]
+}
+
+interface PreviewQuiz {
+  source_row: number | null
+  title: string
+  description: string | null
+  is_active: boolean
+  question_prompts: string[]
+  action: 'create' | 'update'
+  errors: string[]
+}
+
+interface PreviewQuestionOption {
+  text: string
+  is_correct: boolean
+}
+
+interface PreviewQuestion {
+  source_row: number | null
+  prompt: string
+  explanation: string | null
+  subject: string | null
+  difficulty: string | null
+  is_active: boolean
+  category_name: string
+  quiz_titles: string[]
+  options: PreviewQuestionOption[]
+  action: 'create' | 'update'
+  errors: string[]
+}
+
+interface PreviewResponse {
+  categories: PreviewCategory[]
+  quizzes: PreviewQuiz[]
+  questions: PreviewQuestion[]
+  warnings: string[]
+}
+
+interface BulkImportResult {
+  categories_created: number
+  categories_updated: number
+  quizzes_created: number
+  quizzes_updated: number
+  questions_created: number
+  questions_updated: number
+}
+
+interface CategoryForm {
+  name: string
+  description: string
+  icon: string
+}
+
+interface QuizForm {
+  title: string
+  description: string
+  is_active: boolean
+  questionPromptsText: string
+}
+
+interface QuestionOptionForm {
+  text: string
+  is_correct: boolean
+}
+
+interface QuestionForm {
+  prompt: string
+  explanation: string
+  subject: string
+  difficulty: string
+  is_active: boolean
+  category_name: string
+  quizTitlesText: string
+  options: QuestionOptionForm[]
+}
+
+const fileInput = ref<HTMLInputElement | null>(null)
+const loading = ref(false)
+const preview = ref<PreviewResponse | null>(null)
+const form = reactive({
+  categories: [] as CategoryForm[],
+  quizzes: [] as QuizForm[],
+  questions: [] as QuestionForm[],
+})
+const uploadError = ref('')
+const commitError = ref('')
+const commitSuccess = ref('')
+const result = ref<BulkImportResult | null>(null)
+const committing = ref(false)
+
+const hasPreview = computed(() => preview.value !== null)
+
+const totalPendingCreates = computed(() => {
+  if (!preview.value) return 0
+  return [
+    preview.value.categories.filter((category) => category.action === 'create').length,
+    preview.value.quizzes.filter((quiz) => quiz.action === 'create').length,
+    preview.value.questions.filter((question) => question.action === 'create').length,
+  ].reduce((acc, count) => acc + count, 0)
+})
+
+const uploadHint = `Prepare a single Excel workbook (.xlsx) with sheets named “Categories”, “Quizzes”, and “Questions”.
+Use headers “Name/Description/Icon” for categories, “Title/Description/Is Active/Questions” for quizzes, and include
+columns for “Prompt, Explanation, Subject, Difficulty, Category, Option 1..n, Correct Option, Quizzes” for questions.`
+
+const hasRowErrors = computed(() => {
+  if (!preview.value) return false
+  return (
+    preview.value.categories.some((category) => category.errors.length > 0) ||
+    preview.value.quizzes.some((quiz) => quiz.errors.length > 0) ||
+    preview.value.questions.some((question) => question.errors.length > 0)
+  )
+})
+
+const pickFile = () => {
+  commitError.value = ''
+  commitSuccess.value = ''
+  result.value = null
+  fileInput.value?.click()
+}
+
+const formatWarnings = computed(() => preview.value?.warnings ?? [])
+
+const resetForm = () => {
+  form.categories = []
+  form.quizzes = []
+  form.questions = []
+}
+
+const prepareForm = (data: PreviewResponse) => {
+  resetForm()
+  form.categories = data.categories.map((category) => ({
+    name: category.name,
+    description: category.description ?? '',
+    icon: category.icon ?? '',
+  }))
+  form.quizzes = data.quizzes.map((quiz) => ({
+    title: quiz.title,
+    description: quiz.description ?? '',
+    is_active: quiz.is_active,
+    questionPromptsText: quiz.question_prompts.join(', '),
+  }))
+  form.questions = data.questions.map((question) => ({
+    prompt: question.prompt,
+    explanation: question.explanation ?? '',
+    subject: question.subject ?? '',
+    difficulty: question.difficulty ?? '',
+    is_active: question.is_active,
+    category_name: question.category_name,
+    quizTitlesText: question.quiz_titles.join(', '),
+    options: question.options.map((option) => ({ ...option })),
+  }))
+}
+
+const handleFileChange = async (event: Event) => {
+  const target = event.target as HTMLInputElement | null
+  if (!target?.files?.length) return
+  const file = target.files[0]
+  uploadError.value = ''
+  commitError.value = ''
+  commitSuccess.value = ''
+  result.value = null
+
+  const formData = new FormData()
+  formData.append('file', file)
+
+  loading.value = true
+  try {
+    const { data } = await http.post<PreviewResponse>('/admin/bulk-import/preview', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    preview.value = data
+    prepareForm(data)
+  } catch (error: any) {
+    uploadError.value = error?.response?.data?.detail || 'Unable to read the workbook.'
+    preview.value = null
+    resetForm()
+  } finally {
+    loading.value = false
+    if (target) {
+      target.value = ''
+    }
+  }
+}
+
+const markCorrectOption = (questionIndex: number, optionIndex: number) => {
+  const question = form.questions[questionIndex]
+  question.options = question.options.map((option, index) => ({
+    ...option,
+    is_correct: index === optionIndex,
+  }))
+}
+
+const addOption = (questionIndex: number) => {
+  form.questions[questionIndex].options.push({ text: '', is_correct: false })
+}
+
+const removeOption = (questionIndex: number, optionIndex: number) => {
+  const options = form.questions[questionIndex].options
+  if (options.length <= 2) return
+  options.splice(optionIndex, 1)
+}
+
+const splitList = (value: string) =>
+  value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+
+const commitImport = async () => {
+  if (!preview.value) return
+  committing.value = true
+  commitError.value = ''
+  commitSuccess.value = ''
+  result.value = null
+
+  const payload = {
+    categories: form.categories.map((category) => ({
+      name: category.name,
+      description: category.description || null,
+      icon: category.icon || null,
+    })),
+    quizzes: form.quizzes.map((quiz) => ({
+      title: quiz.title,
+      description: quiz.description || null,
+      is_active: quiz.is_active,
+      question_prompts: splitList(quiz.questionPromptsText),
+    })),
+    questions: form.questions.map((question) => ({
+      prompt: question.prompt,
+      explanation: question.explanation || null,
+      subject: question.subject || null,
+      difficulty: question.difficulty || null,
+      is_active: question.is_active,
+      category_name: question.category_name,
+      quiz_titles: splitList(question.quizTitlesText),
+      options: question.options.map((option) => ({
+        text: option.text,
+        is_correct: option.is_correct,
+      })),
+    })),
+  }
+
+  try {
+    const { data } = await http.post<BulkImportResult>('/admin/bulk-import/commit', payload)
+    result.value = data
+    commitSuccess.value = `Import complete. ${data.questions_created + data.questions_updated} questions processed.`
+  } catch (error: any) {
+    commitError.value = error?.response?.data?.detail || 'Import failed. Review the data and try again.'
+  } finally {
+    committing.value = false
+  }
+}
+
+const pendingSummary = computed(() => {
+  if (!preview.value) return []
+  return [
+    {
+      label: 'Categories',
+      create: preview.value.categories.filter((item) => item.action === 'create').length,
+      update: preview.value.categories.filter((item) => item.action === 'update').length,
+    },
+    {
+      label: 'Quizzes',
+      create: preview.value.quizzes.filter((item) => item.action === 'create').length,
+      update: preview.value.quizzes.filter((item) => item.action === 'update').length,
+    },
+    {
+      label: 'Questions',
+      create: preview.value.questions.filter((item) => item.action === 'create').length,
+      update: preview.value.questions.filter((item) => item.action === 'update').length,
+    },
+  ]
+})
+
+const hasData = computed(() =>
+  form.categories.length + form.quizzes.length + form.questions.length > 0
+)
+</script>
+
+<template>
+  <section class="space-y-8">
+    <header class="space-y-2">
+      <h1 class="text-3xl font-semibold text-slate-900">Bulk content importer</h1>
+      <p class="max-w-3xl text-sm text-slate-500">
+        Upload a structured Excel workbook to create or update categories, questions, and quizzes in one
+        step. Preview the detected changes, adjust the values inline, then publish everything together.
+      </p>
+    </header>
+
+    <section class="rounded-3xl border border-dashed border-slate-300 bg-white/60 p-6">
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div class="space-y-2">
+          <h2 class="text-lg font-semibold text-slate-900">Upload workbook</h2>
+          <p class="text-sm text-slate-500">{{ uploadHint }}</p>
+        </div>
+        <div class="flex items-center gap-3">
+          <button
+            type="button"
+            class="rounded-full border border-slate-200 px-5 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+            @click="pickFile"
+          >
+            Choose file
+          </button>
+          <input
+            ref="fileInput"
+            type="file"
+            accept=".xlsx"
+            class="hidden"
+            @change="handleFileChange"
+          />
+        </div>
+      </div>
+      <p v-if="loading" class="mt-4 text-sm text-slate-500">Parsing workbook…</p>
+      <p v-if="uploadError" class="mt-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-600">
+        {{ uploadError }}
+      </p>
+      <ul v-if="formatWarnings.length > 0" class="mt-4 space-y-2 text-sm text-amber-700">
+        <li v-for="warning in formatWarnings" :key="warning" class="rounded-2xl bg-amber-50 px-4 py-2">
+          {{ warning }}
+        </li>
+      </ul>
+    </section>
+
+    <section v-if="hasPreview && preview" class="space-y-6">
+      <div class="grid gap-4 md:grid-cols-3">
+        <article
+          v-for="item in pendingSummary"
+          :key="item.label"
+          class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">{{ item.label }}</p>
+          <p class="mt-3 text-3xl font-semibold text-slate-900">{{ item.create }} new</p>
+          <p class="text-xs text-slate-500">{{ item.update }} to update</p>
+        </article>
+      </div>
+      <p v-if="hasRowErrors" class="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+        Some rows contain validation issues. Adjust the values below or update the workbook and upload
+        again. The API will perform final validation when you publish.
+      </p>
+
+      <section class="space-y-4">
+        <header class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold text-slate-900">Categories</h2>
+          <p class="text-xs text-slate-500">{{ form.categories.length }} entries detected</p>
+        </header>
+        <div v-if="form.categories.length === 0" class="rounded-3xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
+          No categories were detected in this workbook.
+        </div>
+        <div v-else class="space-y-4">
+          <article
+            v-for="(category, index) in form.categories"
+            :key="index"
+            class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+          >
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                {{ preview.categories[index].action === 'create' ? 'Create' : 'Update' }} ·
+                Row {{ preview.categories[index].source_row ?? '—' }}
+              </p>
+              <p v-if="preview.categories[index].errors.length" class="text-xs text-rose-500">
+                {{ preview.categories[index].errors.join(' · ') }}
+              </p>
+            </div>
+            <div class="mt-4 grid gap-4 md:grid-cols-3">
+              <label class="flex flex-col gap-1 text-sm">
+                <span class="font-medium text-slate-600">Name</span>
+                <input v-model="category.name" type="text" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none" />
+              </label>
+              <label class="flex flex-col gap-1 text-sm md:col-span-2">
+                <span class="font-medium text-slate-600">Description</span>
+                <input v-model="category.description" type="text" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none" />
+              </label>
+              <label class="flex flex-col gap-1 text-sm">
+                <span class="font-medium text-slate-600">Icon</span>
+                <input v-model="category.icon" type="text" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none" />
+              </label>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="space-y-4">
+        <header class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold text-slate-900">Quizzes</h2>
+          <p class="text-xs text-slate-500">{{ form.quizzes.length }} entries detected</p>
+        </header>
+        <div v-if="form.quizzes.length === 0" class="rounded-3xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
+          No quizzes were detected in this workbook.
+        </div>
+        <div v-else class="space-y-4">
+          <article
+            v-for="(quiz, index) in form.quizzes"
+            :key="index"
+            class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+          >
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                {{ preview.quizzes[index].action === 'create' ? 'Create' : 'Update' }} ·
+                Row {{ preview.quizzes[index].source_row ?? '—' }}
+              </p>
+              <p v-if="preview.quizzes[index].errors.length" class="text-xs text-rose-500">
+                {{ preview.quizzes[index].errors.join(' · ') }}
+              </p>
+            </div>
+            <div class="mt-4 grid gap-4 md:grid-cols-2">
+              <label class="flex flex-col gap-1 text-sm">
+                <span class="font-medium text-slate-600">Title</span>
+                <input v-model="quiz.title" type="text" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none" />
+              </label>
+              <label class="flex items-center gap-2 text-sm font-medium text-slate-600">
+                <input v-model="quiz.is_active" type="checkbox" class="rounded border-slate-300 text-slate-900 focus:ring-slate-500" />
+                Active
+              </label>
+              <label class="flex flex-col gap-1 text-sm md:col-span-2">
+                <span class="font-medium text-slate-600">Description</span>
+                <textarea v-model="quiz.description" rows="2" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none"></textarea>
+              </label>
+              <label class="flex flex-col gap-1 text-sm md:col-span-2">
+                <span class="font-medium text-slate-600">Question prompts (comma separated)</span>
+                <textarea v-model="quiz.questionPromptsText" rows="2" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none"></textarea>
+              </label>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="space-y-4">
+        <header class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold text-slate-900">Questions</h2>
+          <p class="text-xs text-slate-500">{{ form.questions.length }} entries detected</p>
+        </header>
+        <div v-if="form.questions.length === 0" class="rounded-3xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
+          No questions were detected in this workbook.
+        </div>
+        <div v-else class="space-y-4">
+          <article
+            v-for="(question, index) in form.questions"
+            :key="index"
+            class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+          >
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                {{ preview.questions[index].action === 'create' ? 'Create' : 'Update' }} ·
+                Row {{ preview.questions[index].source_row ?? '—' }}
+              </p>
+              <p v-if="preview.questions[index].errors.length" class="text-xs text-rose-500">
+                {{ preview.questions[index].errors.join(' · ') }}
+              </p>
+            </div>
+            <div class="mt-4 grid gap-4 md:grid-cols-2">
+              <label class="flex flex-col gap-1 text-sm md:col-span-2">
+                <span class="font-medium text-slate-600">Prompt</span>
+                <textarea v-model="question.prompt" rows="3" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none"></textarea>
+              </label>
+              <label class="flex flex-col gap-1 text-sm md:col-span-2">
+                <span class="font-medium text-slate-600">Explanation</span>
+                <textarea v-model="question.explanation" rows="3" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none"></textarea>
+              </label>
+              <label class="flex flex-col gap-1 text-sm">
+                <span class="font-medium text-slate-600">Subject</span>
+                <input v-model="question.subject" type="text" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none" />
+              </label>
+              <label class="flex flex-col gap-1 text-sm">
+                <span class="font-medium text-slate-600">Difficulty</span>
+                <input v-model="question.difficulty" type="text" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none" />
+              </label>
+              <label class="flex items-center gap-2 text-sm font-medium text-slate-600">
+                <input v-model="question.is_active" type="checkbox" class="rounded border-slate-300 text-slate-900 focus:ring-slate-500" />
+                Active
+              </label>
+              <label class="flex flex-col gap-1 text-sm">
+                <span class="font-medium text-slate-600">Category</span>
+                <input v-model="question.category_name" type="text" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none" />
+              </label>
+              <label class="flex flex-col gap-1 text-sm md:col-span-2">
+                <span class="font-medium text-slate-600">Assign to quizzes (comma separated titles)</span>
+                <textarea v-model="question.quizTitlesText" rows="2" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none"></textarea>
+              </label>
+            </div>
+            <div class="mt-6 space-y-3">
+              <h3 class="text-sm font-semibold text-slate-700">Answer options</h3>
+              <div
+                v-for="(option, optionIndex) in question.options"
+                :key="optionIndex"
+                class="flex flex-col gap-2 rounded-2xl border border-slate-200 p-4 md:flex-row md:items-center md:justify-between"
+              >
+                <div class="flex flex-1 flex-col gap-1 text-sm">
+                  <span class="font-medium text-slate-600">Option {{ optionIndex + 1 }}</span>
+                  <input v-model="option.text" type="text" class="rounded-2xl border border-slate-200 px-4 py-2 focus:border-slate-400 focus:outline-none" />
+                </div>
+                <div class="flex items-center gap-3 text-sm">
+                  <label class="inline-flex items-center gap-2 font-medium text-slate-600">
+                    <input
+                      :name="`correct-${index}`"
+                      type="radio"
+                      :checked="option.is_correct"
+                      @change="markCorrectOption(index, optionIndex)"
+                      class="text-slate-900 focus:ring-slate-500"
+                    />
+                    Correct answer
+                  </label>
+                  <button
+                    type="button"
+                    class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
+                    @click="removeOption(index, optionIndex)"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+              <button
+                type="button"
+                class="rounded-full border border-slate-200 px-4 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
+                @click="addOption(index)"
+              >
+                Add option
+              </button>
+            </div>
+          </article>
+        </div>
+      </section>
+    </section>
+
+    <section v-if="hasData" class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-slate-900">Publish changes</h2>
+          <p class="text-sm text-slate-500">
+            Review the adjustments above. When you publish, the API will create new records and update any
+            matching items.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+          :disabled="committing"
+          @click="commitImport"
+        >
+          {{ committing ? 'Saving…' : 'Publish import' }}
+        </button>
+      </div>
+      <p v-if="commitError" class="mt-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-600">
+        {{ commitError }}
+      </p>
+      <p v-if="commitSuccess" class="mt-4 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+        {{ commitSuccess }}
+      </p>
+      <div v-if="result" class="mt-4 grid gap-3 md:grid-cols-3">
+        <div class="rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-600">
+          <p class="font-semibold text-slate-900">Categories</p>
+          <p>{{ result.categories_created }} created · {{ result.categories_updated }} updated</p>
+        </div>
+        <div class="rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-600">
+          <p class="font-semibold text-slate-900">Quizzes</p>
+          <p>{{ result.quizzes_created }} created · {{ result.quizzes_updated }} updated</p>
+        </div>
+        <div class="rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-600">
+          <p class="font-semibold text-slate-900">Questions</p>
+          <p>{{ result.questions_created }} created · {{ result.questions_updated }} updated</p>
+        </div>
+      </div>
+    </section>
+  </section>
+</template>

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -96,6 +96,12 @@ const routes = [
     meta: { requiresAdmin: true, title: 'Quiz Library' },
   },
   {
+    path: '/admin/import',
+    name: 'admin-bulk-import',
+    component: () => import('../pages/admin/BulkImport.vue'),
+    meta: { requiresAdmin: true, title: 'Bulk Import' },
+  },
+  {
     path: '/admin/categories',
     name: 'admin-categories',
     component: () => import('../pages/admin/CategoriesCRUD.vue'),

--- a/services/api/app/api/routes/admin.py
+++ b/services/api/app/api/routes/admin.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Iterable, List
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db_session, require_admin, require_superuser
+from app.api.deps import (
+    get_db_session,
+    require_admin,
+    require_content_manager,
+    require_superuser,
+    resolve_content_organization,
+)
 from app.core.security import get_password_hash
 from app.models.category import Category
 from app.models.organization import OrgMembership, Organization
-from app.models.question import Question, QuizQuestion
+from app.models.question import Option, Question, QuizQuestion
 from app.models.quiz import Quiz
 from app.models.user import LearnerUser, OrganizationUser, PlatformUser, User
 from app.schemas.admin import AdminCategorySnapshot, AdminOverview, AdminRecentQuiz, AdminTotals
@@ -25,9 +31,20 @@ from app.schemas.management import (
     MailConfigIn,
     MailConfigOut,
 )
+from app.schemas.bulk_import import (
+    BulkCategoryPayload,
+    BulkImportCommit,
+    BulkImportPreview,
+    BulkImportResult,
+    BulkQuestionOption,
+    BulkQuestionPayload,
+    BulkQuizPayload,
+)
 from app.services.config_service import ConfigService
 from app.services.email_service import EmailService
 from app.services.notification_service import NotificationService
+from app.services.bulk_import_service import BulkImportFormatError, parse_workbook
+from app.core.strings import slugify
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -377,3 +394,486 @@ def create_admin_notification(
     )
     db.commit()
     return AdminNotificationResult(notified_users=notified)
+
+
+@router.post("/bulk-import/preview", response_model=BulkImportPreview)
+async def preview_bulk_import(
+    organization_id: int | None = Query(default=None),
+    file: UploadFile = File(...),
+    current_user: User = Depends(require_content_manager),
+    db: Session = Depends(get_db_session),
+) -> BulkImportPreview:
+    filename = (file.filename or "").lower()
+    if not filename.endswith(".xlsx"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Upload an Excel .xlsx workbook.",
+        )
+
+    content = await file.read()
+    if not content:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File is empty.")
+
+    try:
+        parsed = parse_workbook(content)
+    except BulkImportFormatError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    target_org_id = resolve_content_organization(
+        current_user,
+        organization_id,
+        allow_global_for_admin=True,
+    )
+
+    existing_categories = _fetch_category_map(db, target_org_id)
+    existing_quizzes = _fetch_quiz_map(db, target_org_id)
+    existing_questions = _fetch_question_map(db, target_org_id)
+
+    category_slug_counts: dict[str, int] = {}
+    categories_preview: list[BulkCategoryPreview] = []
+
+    for category in parsed.categories:
+        slug = slugify(category.name) if category.name else ""
+        errors = list(category.errors)
+        if slug:
+            category_slug_counts[slug] = category_slug_counts.get(slug, 0) + 1
+            if category_slug_counts[slug] > 1:
+                errors.append("Duplicate category name in the workbook.")
+        elif not errors:
+            errors.append("Category name is required.")
+
+        existing = existing_categories.get(slug) if slug else None
+        categories_preview.append(
+            BulkCategoryPreview(
+                source_row=category.source_row,
+                name=category.name,
+                description=category.description,
+                icon=category.icon,
+                slug=slug,
+                action="update" if existing else "create",
+                errors=errors,
+            )
+        )
+
+    valid_category_slugs = {
+        item.slug
+        for item in categories_preview
+        if item.slug and not item.errors
+    } | set(existing_categories.keys())
+
+    quiz_title_counts: dict[str, int] = {}
+    quizzes_preview: list[BulkQuizPreview] = []
+    available_prompt_keys = {
+        question.prompt.strip().lower()
+        for question in parsed.questions
+        if question.prompt.strip()
+    } | set(existing_questions.keys())
+
+    for quiz in parsed.quizzes:
+        title = quiz.title.strip() if quiz.title else ""
+        title_key = title.lower()
+        errors = list(quiz.errors)
+        if title_key:
+            quiz_title_counts[title_key] = quiz_title_counts.get(title_key, 0) + 1
+            if quiz_title_counts[title_key] > 1:
+                errors.append("Duplicate quiz title in the workbook.")
+        else:
+            errors.append("Quiz title is required.")
+
+        existing = existing_quizzes.get(title_key) if title_key else None
+        if existing and target_org_id not in {existing.organization_id, None}:
+            errors.append("Quiz belongs to another organization.")
+
+        for prompt in quiz.question_prompts:
+            prompt_key = prompt.strip().lower()
+            if prompt_key and prompt_key not in available_prompt_keys:
+                errors.append(f"Question '{prompt}' is not defined in this import or library.")
+
+        quizzes_preview.append(
+            BulkQuizPreview(
+                source_row=quiz.source_row,
+                title=quiz.title,
+                description=quiz.description,
+                is_active=quiz.is_active,
+                question_prompts=quiz.question_prompts,
+                action="update" if existing else "create",
+                errors=errors,
+            )
+        )
+
+    quiz_titles_in_sheet = {
+        quiz.title.strip().lower()
+        for quiz in parsed.quizzes
+        if quiz.title.strip()
+    }
+    quiz_titles_in_sheet |= set(existing_quizzes.keys())
+
+    question_prompt_counts: dict[str, int] = {}
+    questions_preview: list[BulkQuestionPreview] = []
+    for question in parsed.questions:
+        prompt = question.prompt.strip() if question.prompt else ""
+        prompt_key = prompt.lower()
+        errors = list(question.errors)
+        if prompt_key:
+            question_prompt_counts[prompt_key] = question_prompt_counts.get(prompt_key, 0) + 1
+            if question_prompt_counts[prompt_key] > 1:
+                errors.append("Duplicate question prompt in the workbook.")
+        else:
+            errors.append("Question prompt is required.")
+
+        category_slug = slugify(question.category_name) if question.category_name else ""
+        if category_slug not in valid_category_slugs:
+            errors.append(
+                f"Category '{question.category_name or 'Unknown'}' is not defined in the Categories sheet or existing library."
+            )
+
+        for title in question.quiz_titles:
+            title_key = title.strip().lower()
+            if title_key and title_key not in quiz_titles_in_sheet:
+                errors.append(f"Quiz '{title}' is not defined in the Quizzes sheet or existing library.")
+
+        existing = existing_questions.get(prompt_key) if prompt_key else None
+        if existing and target_org_id not in {existing.organization_id, None}:
+            errors.append("Question belongs to another organization.")
+
+        questions_preview.append(
+            BulkQuestionPreview(
+                source_row=question.source_row,
+                prompt=question.prompt,
+                explanation=question.explanation,
+                subject=question.subject,
+                difficulty=question.difficulty,
+                is_active=question.is_active,
+                category_name=question.category_name,
+                quiz_titles=question.quiz_titles,
+                options=[
+                    BulkQuestionOption(text=option.text, is_correct=option.is_correct)
+                    for option in question.options
+                ],
+                action="update" if existing else "create",
+                errors=errors,
+            )
+        )
+
+    return BulkImportPreview(
+        categories=categories_preview,
+        quizzes=quizzes_preview,
+        questions=questions_preview,
+        warnings=parsed.warnings,
+    )
+
+
+@router.post("/bulk-import/commit", response_model=BulkImportResult)
+def commit_bulk_import(
+    payload: BulkImportCommit,
+    organization_id: int | None = Query(default=None),
+    current_user: User = Depends(require_content_manager),
+    db: Session = Depends(get_db_session),
+) -> BulkImportResult:
+    target_org_id = resolve_content_organization(
+        current_user,
+        organization_id,
+        allow_global_for_admin=True,
+    )
+
+    if not payload.categories and not payload.questions and not payload.quizzes:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No records to import.")
+
+    _ensure_unique_categories(payload.categories)
+    _ensure_valid_questions(payload.questions)
+    _ensure_unique_quizzes(payload.quizzes)
+
+    existing_categories = _fetch_category_map(db, target_org_id)
+    existing_quizzes = _fetch_quiz_map(db, target_org_id)
+
+    quiz_titles_defined = {quiz.title.strip().lower(): quiz for quiz in payload.quizzes if quiz.title.strip()}
+    for question in payload.questions:
+        for title in question.quiz_titles:
+            title_key = title.strip().lower()
+            if title_key and title_key not in quiz_titles_defined and title_key not in existing_quizzes:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Question '{question.prompt}' references quiz '{title}' that is not defined.",
+                )
+
+    quiz_prompt_requirements = _collect_quiz_prompts(payload)
+    all_needed_prompts = set()
+    for prompts in quiz_prompt_requirements.values():
+        all_needed_prompts.update(prompts)
+    all_needed_prompts.update(question.prompt for question in payload.questions)
+
+    existing_questions = _fetch_question_map(db, target_org_id, prompts=all_needed_prompts)
+
+    category_lookup = dict(existing_categories)
+
+    result = BulkImportResult(
+        categories_created=0,
+        categories_updated=0,
+        quizzes_created=0,
+        quizzes_updated=0,
+        questions_created=0,
+        questions_updated=0,
+    )
+
+    try:
+        # Categories
+        for category in payload.categories:
+            slug = slugify(category.name)
+            existing = category_lookup.get(slug)
+            description = _normalize_optional(category.description)
+            icon = _normalize_optional(category.icon)
+            if existing is not None:
+                existing.name = category.name.strip()
+                existing.description = description
+                existing.icon = icon
+                existing.organization_id = target_org_id
+                result.categories_updated += 1
+            else:
+                new_category = Category(
+                    name=category.name.strip(),
+                    slug=slug,
+                    description=description,
+                    icon=icon,
+                    organization_id=target_org_id,
+                )
+                db.add(new_category)
+                db.flush()
+                category_lookup[slug] = new_category
+                result.categories_created += 1
+
+        # Questions
+        question_lookup = dict(existing_questions)
+        for question in payload.questions:
+            prompt = question.prompt.strip()
+            prompt_key = prompt.lower()
+            category_slug = slugify(question.category_name)
+            category = category_lookup.get(category_slug)
+            if category is None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Category '{question.category_name}' is not available.",
+                )
+
+            existing_question = question_lookup.get(prompt_key)
+            explanation = _normalize_optional(question.explanation)
+            subject = _normalize_optional(question.subject)
+            difficulty = _normalize_optional(question.difficulty)
+
+            if existing_question is None:
+                new_question = Question(
+                    prompt=prompt,
+                    explanation=explanation,
+                    subject=subject,
+                    difficulty=difficulty,
+                    is_active=question.is_active,
+                    category_id=category.id,
+                    organization_id=target_org_id,
+                )
+                db.add(new_question)
+                db.flush()
+                for option in question.options:
+                    db.add(
+                        Option(
+                            question_id=new_question.id,
+                            text=option.text.strip(),
+                            is_correct=option.is_correct,
+                        )
+                    )
+                question_lookup[prompt_key] = new_question
+                result.questions_created += 1
+            else:
+                existing_question.prompt = prompt
+                existing_question.explanation = explanation
+                existing_question.subject = subject
+                existing_question.difficulty = difficulty
+                existing_question.is_active = question.is_active
+                existing_question.category_id = category.id
+                existing_question.organization_id = target_org_id
+                db.query(Option).filter(Option.question_id == existing_question.id).delete(synchronize_session=False)
+                for option in question.options:
+                    db.add(
+                        Option(
+                            question_id=existing_question.id,
+                            text=option.text.strip(),
+                            is_correct=option.is_correct,
+                        )
+                    )
+                result.questions_updated += 1
+                question_lookup[prompt_key] = existing_question
+
+        db.flush()
+
+        # Quizzes
+        for quiz in payload.quizzes:
+            title = quiz.title.strip()
+            title_key = title.lower()
+            description = _normalize_optional(quiz.description)
+            existing_quiz = existing_quizzes.get(title_key)
+            if existing_quiz is None:
+                existing_quiz = Quiz(
+                    title=title,
+                    description=description,
+                    is_active=quiz.is_active,
+                    organization_id=target_org_id,
+                )
+                db.add(existing_quiz)
+                db.flush()
+                existing_quizzes[title_key] = existing_quiz
+                result.quizzes_created += 1
+            else:
+                existing_quiz.description = description
+                existing_quiz.is_active = quiz.is_active
+                existing_quiz.organization_id = target_org_id
+                result.quizzes_updated += 1
+
+            prompts = _dedupe_preserve_order(quiz.question_prompts + quiz_prompt_requirements.get(title_key, []))
+            db.query(QuizQuestion).filter(QuizQuestion.quiz_id == existing_quiz.id).delete(synchronize_session=False)
+            for position, prompt in enumerate(prompts, start=1):
+                prompt_key = prompt.strip().lower()
+                question_obj = question_lookup.get(prompt_key)
+                if question_obj is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Quiz '{quiz.title}' references question '{prompt}' that was not found.",
+                    )
+                db.add(
+                    QuizQuestion(
+                        quiz_id=existing_quiz.id,
+                        question_id=question_obj.id,
+                        position=position,
+                    )
+                )
+
+        db.commit()
+    except HTTPException:
+        db.rollback()
+        raise
+    except Exception:
+        db.rollback()
+        raise
+
+    return result
+
+
+def _fetch_category_map(db: Session, organization_id: int | None) -> dict[str, Category]:
+    stmt = select(Category)
+    if organization_id is None:
+        stmt = stmt.where(Category.organization_id.is_(None))
+    else:
+        stmt = stmt.where(Category.organization_id == organization_id)
+    return {category.slug: category for category in db.scalars(stmt).all()}
+
+
+def _fetch_quiz_map(db: Session, organization_id: int | None) -> dict[str, Quiz]:
+    stmt = select(Quiz)
+    if organization_id is None:
+        stmt = stmt.where(Quiz.organization_id.is_(None))
+    else:
+        stmt = stmt.where(Quiz.organization_id == organization_id)
+    return {quiz.title.strip().lower(): quiz for quiz in db.scalars(stmt).all()}
+
+
+def _fetch_question_map(
+    db: Session,
+    organization_id: int | None,
+    *,
+    prompts: Iterable[str] | None = None,
+) -> dict[str, Question]:
+    stmt = select(Question)
+    if prompts:
+        normalized_prompts = {prompt.strip() for prompt in prompts if prompt.strip()}
+        if normalized_prompts:
+            stmt = stmt.where(Question.prompt.in_(normalized_prompts))
+    if organization_id is None:
+        stmt = stmt.where(Question.organization_id.is_(None))
+    else:
+        stmt = stmt.where(Question.organization_id == organization_id)
+    return {question.prompt.strip().lower(): question for question in db.scalars(stmt).all()}
+
+
+def _normalize_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def _ensure_unique_categories(categories: list[BulkCategoryPayload]) -> None:
+    seen: set[str] = set()
+    for category in categories:
+        name = category.name.strip()
+        if not name:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Category name cannot be empty.")
+        slug = slugify(name)
+        if slug in seen:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Duplicate category name '{category.name}' in payload.",
+            )
+        seen.add(slug)
+
+
+def _ensure_valid_questions(questions: list[BulkQuestionPayload]) -> None:
+    seen: set[str] = set()
+    for question in questions:
+        prompt = question.prompt.strip()
+        if not prompt:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Question prompt cannot be empty.")
+        key = prompt.lower()
+        if key in seen:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Duplicate question prompt '{question.prompt}' in payload.",
+            )
+        seen.add(key)
+        options = getattr(question, "options", [])
+        if len(options) < 2:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Question '{question.prompt}' requires at least two options.",
+            )
+        if not any(option.is_correct for option in options):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Question '{question.prompt}' requires a correct option.",
+            )
+
+
+def _ensure_unique_quizzes(quizzes: list[BulkQuizPayload]) -> None:
+    seen: set[str] = set()
+    for quiz in quizzes:
+        title = quiz.title.strip()
+        if not title:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Quiz title cannot be empty.")
+        key = title.lower()
+        if key in seen:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Duplicate quiz title '{quiz.title}' in payload.",
+            )
+        seen.add(key)
+
+
+def _collect_quiz_prompts(payload: BulkImportCommit) -> dict[str, list[str]]:
+    mapping: dict[str, list[str]] = {}
+    for question in payload.questions:
+        for title in question.quiz_titles:
+            trimmed = title.strip()
+            if not trimmed:
+                continue
+            key = trimmed.lower()
+            mapping.setdefault(key, []).append(question.prompt)
+    return mapping
+
+
+def _dedupe_preserve_order(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        trimmed = item.strip()
+        key = trimmed.lower()
+        if not trimmed or key in seen:
+            continue
+        seen.add(key)
+        result.append(trimmed)
+    return result

--- a/services/api/app/models/organization.py
+++ b/services/api/app/models/organization.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List
 
-from sqlalchemy import DateTime, Enum, ForeignKey, Index, String, UniqueConstraint, func, text
+from sqlalchemy import DateTime, Enum, ForeignKey, Index, JSON, String, UniqueConstraint, func, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
 
+
+JSON_DICT = JSON().with_variant(JSONB(astext_type=String()), "postgresql")
 
 class Organization(Base):
     __tablename__ = "organizations"
@@ -132,7 +134,7 @@ class Notification(Base):
     type: Mapped[str] = mapped_column(String(64), nullable=False)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     body: Mapped[str] = mapped_column(String(1024), nullable=False)
-    meta_json: Mapped[dict | None] = mapped_column(JSONB(astext_type=String()), nullable=True)
+    meta_json: Mapped[dict | None] = mapped_column(JSON_DICT, nullable=True)
     read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
@@ -150,7 +152,7 @@ class EmailEvent(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     to_email: Mapped[str] = mapped_column(String(255), nullable=False)
     template: Mapped[str] = mapped_column(String(128), nullable=False)
-    payload_json: Mapped[dict | None] = mapped_column(JSONB(astext_type=String()), nullable=True)
+    payload_json: Mapped[dict | None] = mapped_column(JSON_DICT, nullable=True)
     status: Mapped[str] = mapped_column(
         Enum("queued", "sent", "failed", name="email_event_status", native_enum=False),
         nullable=False,
@@ -168,7 +170,7 @@ class AppConfig(Base):
     __tablename__ = "app_configs"
 
     key: Mapped[str] = mapped_column(String(255), primary_key=True)
-    value_json: Mapped[dict | None] = mapped_column(JSONB(astext_type=String()), nullable=True)
+    value_json: Mapped[dict | None] = mapped_column(JSON_DICT, nullable=True)
     scope: Mapped[str] = mapped_column(
         Enum("global", "org", name="app_config_scope", native_enum=False),
         nullable=False,

--- a/services/api/app/schemas/bulk_import.py
+++ b/services/api/app/schemas/bulk_import.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import List, Literal
+
+from pydantic import BaseModel, Field
+
+
+class BulkCategoryPreview(BaseModel):
+    source_row: int | None = Field(default=None, description="Row number in the spreadsheet")
+    name: str = Field(..., min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=500)
+    icon: str | None = Field(default=None, max_length=16)
+    slug: str
+    action: Literal["create", "update"]
+    errors: List[str] = Field(default_factory=list)
+
+
+class BulkQuizPreview(BaseModel):
+    source_row: int | None = Field(default=None)
+    title: str = Field(..., min_length=1)
+    description: str | None = Field(default=None)
+    is_active: bool = True
+    question_prompts: List[str] = Field(default_factory=list)
+    action: Literal["create", "update"]
+    errors: List[str] = Field(default_factory=list)
+
+
+class BulkQuestionOption(BaseModel):
+    text: str = Field(..., min_length=1)
+    is_correct: bool = False
+
+
+class BulkQuestionPreview(BaseModel):
+    source_row: int | None = Field(default=None)
+    prompt: str = Field(..., min_length=1)
+    explanation: str | None = Field(default=None)
+    subject: str | None = Field(default=None)
+    difficulty: str | None = Field(default=None)
+    is_active: bool = True
+    category_name: str = Field(..., min_length=1)
+    quiz_titles: List[str] = Field(default_factory=list)
+    options: List[BulkQuestionOption]
+    action: Literal["create", "update"]
+    errors: List[str] = Field(default_factory=list)
+
+
+class BulkImportPreview(BaseModel):
+    categories: List[BulkCategoryPreview]
+    quizzes: List[BulkQuizPreview]
+    questions: List[BulkQuestionPreview]
+    warnings: List[str] = Field(default_factory=list)
+
+
+class BulkCategoryPayload(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=500)
+    icon: str | None = Field(default=None, max_length=16)
+
+
+class BulkQuizPayload(BaseModel):
+    title: str = Field(..., min_length=1)
+    description: str | None = Field(default=None)
+    is_active: bool = True
+    question_prompts: List[str] = Field(default_factory=list)
+
+
+class BulkQuestionPayload(BaseModel):
+    prompt: str = Field(..., min_length=1)
+    explanation: str | None = Field(default=None)
+    subject: str | None = Field(default=None)
+    difficulty: str | None = Field(default=None)
+    is_active: bool = True
+    category_name: str = Field(..., min_length=1)
+    quiz_titles: List[str] = Field(default_factory=list)
+    options: List[BulkQuestionOption]
+
+
+class BulkImportCommit(BaseModel):
+    categories: List[BulkCategoryPayload] = Field(default_factory=list)
+    quizzes: List[BulkQuizPayload] = Field(default_factory=list)
+    questions: List[BulkQuestionPayload] = Field(default_factory=list)
+
+
+class BulkImportResult(BaseModel):
+    categories_created: int
+    categories_updated: int
+    quizzes_created: int
+    quizzes_updated: int
+    questions_created: int
+    questions_updated: int
+

--- a/services/api/app/services/bulk_import_service.py
+++ b/services/api/app/services/bulk_import_service.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from io import BytesIO
+from typing import Any, Dict, Iterable, List, Tuple
+from xml.etree import ElementTree as ET
+from zipfile import BadZipFile, ZipFile
+
+
+class BulkImportFormatError(ValueError):
+    """Raised when the uploaded workbook cannot be parsed."""
+
+
+@dataclass
+class ParsedCategory:
+    source_row: int
+    name: str
+    description: str | None
+    icon: str | None
+    errors: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ParsedQuiz:
+    source_row: int
+    title: str
+    description: str | None
+    is_active: bool
+    question_prompts: List[str]
+    errors: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ParsedQuestionOption:
+    text: str
+    is_correct: bool = False
+
+
+@dataclass
+class ParsedQuestion:
+    source_row: int
+    prompt: str
+    explanation: str | None
+    subject: str | None
+    difficulty: str | None
+    is_active: bool
+    category_name: str
+    quiz_titles: List[str]
+    options: List[ParsedQuestionOption]
+    errors: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ParsedWorkbook:
+    categories: List[ParsedCategory]
+    quizzes: List[ParsedQuiz]
+    questions: List[ParsedQuestion]
+    warnings: List[str] = field(default_factory=list)
+
+
+_CATEGORY_SHEET_NAMES = {"categories", "category", "category setup"}
+_QUIZ_SHEET_NAMES = {"quizzes", "quiz", "quiz setup"}
+_QUESTION_SHEET_NAMES = {"questions", "question bank", "items"}
+
+_NS = {
+    "main": "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+    "rel": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+}
+
+
+def parse_workbook(file_bytes: bytes) -> ParsedWorkbook:
+    try:
+        sheet_map = _load_sheet_map(file_bytes)
+    except (BadZipFile, KeyError, ET.ParseError) as exc:  # noqa: BLE001
+        raise BulkImportFormatError("Unable to read the Excel workbook. Upload a valid .xlsx file.") from exc
+
+    categories_sheet = _locate_sheet(sheet_map.keys(), _CATEGORY_SHEET_NAMES)
+    quizzes_sheet = _locate_sheet(sheet_map.keys(), _QUIZ_SHEET_NAMES)
+    questions_sheet = _locate_sheet(sheet_map.keys(), _QUESTION_SHEET_NAMES)
+
+    warnings: List[str] = []
+    if categories_sheet is None:
+        warnings.append("Categories sheet not found. Expected a sheet named 'Categories'.")
+    if quizzes_sheet is None:
+        warnings.append("Quizzes sheet not found. Expected a sheet named 'Quizzes'.")
+    if questions_sheet is None:
+        warnings.append("Questions sheet not found. Expected a sheet named 'Questions'.")
+
+    categories = _parse_categories(sheet_map[categories_sheet]) if categories_sheet else []
+    quizzes = _parse_quizzes(sheet_map[quizzes_sheet]) if quizzes_sheet else []
+    questions = _parse_questions(sheet_map[questions_sheet]) if questions_sheet else []
+
+    return ParsedWorkbook(
+        categories=categories,
+        quizzes=quizzes,
+        questions=questions,
+        warnings=warnings,
+    )
+
+
+def _locate_sheet(sheet_names: Iterable[str], expected: set[str]) -> str | None:
+    normalized = {name.lower(): name for name in sheet_names}
+    for candidate in expected:
+        lower = candidate.lower()
+        if lower in normalized:
+            return normalized[lower]
+    return None
+
+
+def _parse_categories(rows: List[List[Any]]) -> List[ParsedCategory]:
+    headers = _extract_headers(rows)
+    categories: List[ParsedCategory] = []
+    for row_idx, values in _iter_rows(rows):
+        row_map = _row_to_map(headers, values)
+        name = _normalize_str(_pick(row_map, ["name", "category", "category name"]))
+        description = _normalize_str(_pick(row_map, ["description", "details", "summary"]))
+        icon = _normalize_str(_pick(row_map, ["icon", "emoji"]))
+        if not name:
+            if not _is_empty_row(values):
+                categories.append(
+                    ParsedCategory(
+                        source_row=row_idx,
+                        name="",
+                        description=None,
+                        icon=None,
+                        errors=["Category name is required."],
+                    )
+                )
+            continue
+        categories.append(
+            ParsedCategory(
+                source_row=row_idx,
+                name=name,
+                description=description,
+                icon=icon,
+            )
+        )
+    return categories
+
+
+def _parse_quizzes(rows: List[List[Any]]) -> List[ParsedQuiz]:
+    headers = _extract_headers(rows)
+    quizzes: List[ParsedQuiz] = []
+    for row_idx, values in _iter_rows(rows):
+        row_map = _row_to_map(headers, values)
+        title = _normalize_str(_pick(row_map, ["title", "quiz", "name"]))
+        description = _normalize_str(_pick(row_map, ["description", "details"]))
+        is_active = _parse_bool(_pick(row_map, ["is active", "active", "status"]), default=True)
+        question_raw = _pick(row_map, ["questions", "question prompts", "prompt list"])
+        question_prompts = _split_list(question_raw)
+
+        if not title:
+            if not _is_empty_row(values):
+                quizzes.append(
+                    ParsedQuiz(
+                        source_row=row_idx,
+                        title="",
+                        description=None,
+                        is_active=is_active,
+                        question_prompts=[],
+                        errors=["Quiz title is required."],
+                    )
+                )
+            continue
+
+        quizzes.append(
+            ParsedQuiz(
+                source_row=row_idx,
+                title=title,
+                description=description,
+                is_active=is_active,
+                question_prompts=question_prompts,
+            )
+        )
+    return quizzes
+
+
+def _parse_questions(rows: List[List[Any]]) -> List[ParsedQuestion]:
+    headers = _extract_headers(rows)
+    questions: List[ParsedQuestion] = []
+    for row_idx, values in _iter_rows(rows):
+        row_map = _row_to_map(headers, values)
+        prompt = _normalize_str(_pick(row_map, ["prompt", "question", "text"]))
+        explanation = _normalize_str(_pick(row_map, ["explanation", "rationale", "notes"]))
+        subject = _normalize_str(_pick(row_map, ["subject", "topic"]))
+        difficulty = _normalize_str(_pick(row_map, ["difficulty", "level"]))
+        is_active = _parse_bool(_pick(row_map, ["is active", "active", "status"]), default=True)
+        category_name = _normalize_str(_pick(row_map, ["category", "category name"]))
+        quiz_titles = _split_list(_pick(row_map, ["quizzes", "quiz titles", "assign to quizzes"]))
+
+        option_pairs = _extract_options(headers, values)
+        correct_value = _normalize_str(_pick(row_map, ["correct option", "answer", "correct"]))
+        options = _resolve_options(option_pairs, correct_value)
+
+        errors: List[str] = []
+        if not prompt:
+            if _is_empty_row(values):
+                continue
+            errors.append("Question prompt is required.")
+        if not category_name:
+            errors.append("Category name is required for each question.")
+        if len(options) < 2:
+            errors.append("Provide at least two options.")
+        elif not any(option.is_correct for option in options):
+            errors.append("Select a correct option.")
+
+        if not prompt and _is_empty_row(values):
+            continue
+
+        questions.append(
+            ParsedQuestion(
+                source_row=row_idx,
+                prompt=prompt or "",
+                explanation=explanation,
+                subject=subject,
+                difficulty=difficulty,
+                is_active=is_active,
+                category_name=category_name or "",
+                quiz_titles=quiz_titles,
+                options=options,
+                errors=errors,
+            )
+        )
+    return questions
+
+
+def _extract_headers(rows: List[List[Any]]) -> List[str]:
+    if not rows:
+        return []
+    return [_normalize_header(value) for value in rows[0]]
+
+
+def _iter_rows(rows: List[List[Any]]) -> Iterable[Tuple[int, Tuple[Any, ...]]]:
+    for index, row in enumerate(rows[1:], start=2):
+        yield index, tuple(row)
+
+
+def _row_to_map(headers: List[str], values: Tuple[Any, ...]) -> Dict[str, Any]:
+    row: Dict[str, Any] = {}
+    for index, header in enumerate(headers):
+        if not header:
+            continue
+        value = values[index] if index < len(values) else None
+        row[header] = value
+    return row
+
+
+def _extract_options(headers: List[str], values: Tuple[Any, ...]) -> List[Tuple[str, str]]:
+    options: List[Tuple[str, str]] = []
+    for index, header in enumerate(headers):
+        if not header or not header.startswith("option"):
+            continue
+        value = values[index] if index < len(values) else None
+        normalized_value = _normalize_str(value)
+        if normalized_value:
+            options.append((header, normalized_value))
+    return options
+
+
+def _resolve_options(option_pairs: List[Tuple[str, str]], correct_value: str | None) -> List[ParsedQuestionOption]:
+    options: List[ParsedQuestionOption] = []
+    correct_index = _resolve_correct_index(option_pairs, correct_value)
+    for idx, (_, text) in enumerate(option_pairs):
+        options.append(ParsedQuestionOption(text=text, is_correct=(idx == correct_index)))
+    return options
+
+
+def _resolve_correct_index(option_pairs: List[Tuple[str, str]], correct_value: str | None) -> int | None:
+    if correct_value is None:
+        return None
+    normalized = correct_value.lower()
+    for idx, (header, text) in enumerate(option_pairs):
+        header_key = header.replace("option", "").strip()
+        candidates = {
+            text.lower(),
+            header.lower(),
+            header_key.lower(),
+            str(idx + 1),
+        }
+        if idx < 26:
+            candidates.add(chr(ord("a") + idx))
+        if normalized in candidates:
+            return idx
+    return None
+
+
+def _pick(row: Dict[str, Any], keys: List[str]) -> Any:
+    for key in keys:
+        if key in row:
+            return row[key]
+    return None
+
+
+def _split_list(value: Any) -> List[str]:
+    text = _normalize_str(value)
+    if not text:
+        return []
+    separators = [",", ";", "|"]
+    for separator in separators[1:]:
+        text = text.replace(separator, separators[0])
+    parts = [part.strip() for part in text.split(separators[0])]
+    return [part for part in parts if part]
+
+
+def _normalize_header(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().lower()
+
+
+def _normalize_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        trimmed = value.strip()
+        return trimmed or None
+    converted = str(value).strip()
+    return converted or None
+
+
+def _parse_bool(value: Any, *, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    normalized = str(value).strip().lower()
+    if normalized in {"true", "yes", "y", "1", "active", "publish"}:
+        return True
+    if normalized in {"false", "no", "n", "0", "inactive", "draft"}:
+        return False
+    return default
+
+
+def _is_empty_row(values: Tuple[Any, ...]) -> bool:
+    return all(_normalize_str(value) is None for value in values)
+
+
+def _load_sheet_map(file_bytes: bytes) -> Dict[str, List[List[Any]]]:
+    with ZipFile(BytesIO(file_bytes)) as archive:
+        workbook_xml = archive.read("xl/workbook.xml")
+        workbook_tree = ET.fromstring(workbook_xml)
+        rels_tree = ET.fromstring(archive.read("xl/_rels/workbook.xml.rels"))
+        relationships = {
+            rel.attrib["Id"]: rel.attrib["Target"]
+            for rel in rels_tree.findall("rel:Relationship", {"rel": _NS["rel"]})
+        }
+
+        shared_strings = _parse_shared_strings(archive)
+
+        sheets: Dict[str, List[List[Any]]] = {}
+        for sheet in workbook_tree.findall("main:sheets/main:sheet", _NS):
+            name = sheet.attrib["name"]
+            rel_id = sheet.attrib[f"{{{_NS['rel']}}}id"]
+            target = relationships.get(rel_id)
+            if not target:
+                continue
+            if not target.startswith("/"):
+                sheet_path = f"xl/{target}"
+            else:
+                sheet_path = target.lstrip("/")
+            sheet_rows = _parse_sheet(archive, sheet_path, shared_strings)
+            sheets[name] = sheet_rows
+        return sheets
+
+
+def _parse_sheet(archive: ZipFile, sheet_path: str, shared_strings: List[str]) -> List[List[Any]]:
+    try:
+        xml = archive.read(sheet_path)
+    except KeyError as exc:
+        raise BulkImportFormatError(f"Worksheet '{sheet_path}' is missing from the workbook.") from exc
+
+    tree = ET.fromstring(xml)
+    rows: List[List[Any]] = []
+    for row in tree.findall("main:sheetData/main:row", _NS):
+        row_map: Dict[int, Any] = {}
+        max_index = 0
+        for cell in row.findall("main:c", _NS):
+            ref = cell.attrib.get("r")
+            column_index = _column_index(ref)
+            value = _parse_cell(cell, shared_strings)
+            row_map[column_index] = value
+            if column_index > max_index:
+                max_index = column_index
+        if max_index == 0:
+            rows.append([])
+            continue
+        row_values = [row_map.get(index) for index in range(1, max_index + 1)]
+        rows.append(row_values)
+    return rows
+
+
+def _parse_shared_strings(archive: ZipFile) -> List[str]:
+    try:
+        xml = archive.read("xl/sharedStrings.xml")
+    except KeyError:
+        return []
+    tree = ET.fromstring(xml)
+    values: List[str] = []
+    for item in tree.findall("main:si", _NS):
+        texts = [node.text or "" for node in item.findall(".//main:t", _NS)]
+        values.append("".join(texts))
+    return values
+
+
+def _parse_cell(cell: ET.Element, shared_strings: List[str]) -> Any:
+    cell_type = cell.attrib.get("t")
+    if cell_type == "s":
+        index_text = cell.findtext("main:v", namespaces=_NS)
+        try:
+            index = int(index_text) if index_text is not None else 0
+        except ValueError:
+            index = 0
+        if 0 <= index < len(shared_strings):
+            return shared_strings[index]
+        return ""
+    if cell_type == "b":
+        value = cell.findtext("main:v", namespaces=_NS)
+        return value in {"1", "true", "TRUE"}
+    if cell_type == "inlineStr":
+        texts = [node.text or "" for node in cell.findall("main:is/main:t", _NS)]
+        return "".join(texts)
+    value = cell.findtext("main:v", namespaces=_NS)
+    return value
+
+
+def _column_index(cell_ref: str | None) -> int:
+    if not cell_ref:
+        return 1
+    letters = "".join(char for char in cell_ref if char.isalpha())
+    if not letters:
+        return 1
+    index = 0
+    for char in letters:
+        index = index * 26 + (ord(char.upper()) - ord("A") + 1)
+    return index

--- a/services/api/tests/test_bulk_import.py
+++ b/services/api/tests/test_bulk_import.py
@@ -1,0 +1,236 @@
+from io import BytesIO
+from zipfile import ZipFile
+from xml.sax.saxutils import escape
+from sqlalchemy import select
+
+from app.models.category import Category
+from app.models.question import Option, Question, QuizQuestion
+from app.models.quiz import Quiz
+
+try:  # pragma: no cover - allow direct execution
+    from .test_admin_management import _auth_headers
+except ImportError:  # pragma: no cover
+    from tests.test_admin_management import _auth_headers
+from .test_auth import TestingSessionLocal, client
+
+
+def _build_workbook() -> bytes:
+    buffer = BytesIO()
+
+    def build_sheet(rows: list[list[str | bool]]) -> str:
+        def column_letter(index: int) -> str:
+            letters = ""
+            while index > 0:
+                index, remainder = divmod(index - 1, 26)
+                letters = chr(65 + remainder) + letters
+            return letters
+
+        xml_parts: list[str] = [
+            '<?xml version="1.0" encoding="UTF-8"?>',
+            '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">',
+            "<sheetData>",
+        ]
+        for row_index, row_values in enumerate(rows, start=1):
+            xml_parts.append(f'<row r="{row_index}">')
+            for column_index, value in enumerate(row_values, start=1):
+                if value is None:
+                    continue
+                cell_ref = f"{column_letter(column_index)}{row_index}"
+                if isinstance(value, bool):
+                    xml_parts.append(f'<c r="{cell_ref}" t="b"><v>{1 if value else 0}</v></c>')
+                else:
+                    xml_parts.append(
+                        f'<c r="{cell_ref}" t="inlineStr"><is><t>{escape(str(value))}</t></is></c>'
+                    )
+            xml_parts.append("</row>")
+        xml_parts.append("</sheetData></worksheet>")
+        return "".join(xml_parts)
+
+    categories_rows = [
+        ["Name", "Description", "Icon"],
+        ["General Knowledge", "Mixed questions", "book"],
+    ]
+    quizzes_rows = [
+        ["Title", "Description", "Is Active", "Questions"],
+        ["General Quiz", "Quick starter quiz", True, "What is 2 + 2?"],
+    ]
+    questions_rows = [
+        [
+            "Prompt",
+            "Explanation",
+            "Subject",
+            "Difficulty",
+            "Is Active",
+            "Category",
+            "Option 1",
+            "Option 2",
+            "Option 3",
+            "Correct Option",
+            "Quizzes",
+        ],
+        [
+            "What is 2 + 2?",
+            "Basic math.",
+            "Mathematics",
+            "Easy",
+            True,
+            "General Knowledge",
+            "4",
+            "5",
+            "3",
+            "Option 1",
+            "General Quiz",
+        ],
+    ]
+
+    with ZipFile(buffer, "w") as archive:
+        archive.writestr(
+            "[Content_Types].xml",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/worksheets/sheet3.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>""",
+        )
+        archive.writestr(
+            "_rels/.rels",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>""",
+        )
+        archive.writestr(
+            "xl/workbook.xml",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Categories" sheetId="1" r:id="rId1"/>
+    <sheet name="Quizzes" sheetId="2" r:id="rId2"/>
+    <sheet name="Questions" sheetId="3" r:id="rId3"/>
+  </sheets>
+</workbook>""",
+        )
+        archive.writestr(
+            "xl/_rels/workbook.xml.rels",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet3.xml"/>
+</Relationships>""",
+        )
+        archive.writestr("xl/worksheets/sheet1.xml", build_sheet(categories_rows))
+        archive.writestr("xl/worksheets/sheet2.xml", build_sheet(quizzes_rows))
+        archive.writestr("xl/worksheets/sheet3.xml", build_sheet(questions_rows))
+
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+def test_bulk_import_preview_and_commit():
+    headers = _auth_headers()
+    content = _build_workbook()
+
+    preview_response = client.post(
+        "/api/admin/bulk-import/preview",
+        files={
+            "file": (
+                "bulk.xlsx",
+                content,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            )
+        },
+        headers=headers,
+    )
+    assert preview_response.status_code == 200
+    preview = preview_response.json()
+    assert preview["categories"][0]["action"] == "create"
+    assert preview["quizzes"][0]["action"] == "create"
+    assert preview["questions"][0]["action"] == "create"
+
+    commit_payload = {
+        "categories": [
+            {"name": "General Knowledge", "description": "Mixed questions", "icon": "book"}
+        ],
+        "questions": [
+            {
+                "prompt": "What is 2 + 2?",
+                "explanation": "Basic math.",
+                "subject": "Mathematics",
+                "difficulty": "Easy",
+                "is_active": True,
+                "category_name": "General Knowledge",
+                "quiz_titles": ["General Quiz"],
+                "options": [
+                    {"text": "4", "is_correct": True},
+                    {"text": "5", "is_correct": False},
+                    {"text": "3", "is_correct": False},
+                ],
+            }
+        ],
+        "quizzes": [
+            {
+                "title": "General Quiz",
+                "description": "Quick starter quiz",
+                "is_active": True,
+                "question_prompts": ["What is 2 + 2?"],
+            }
+        ],
+    }
+
+    commit_response = client.post(
+        "/api/admin/bulk-import/commit",
+        json=commit_payload,
+        headers=headers,
+    )
+    assert commit_response.status_code == 200
+    result = commit_response.json()
+    assert result["categories_created"] == 1
+    assert result["questions_created"] == 1
+    assert result["quizzes_created"] == 1
+
+    session = TestingSessionLocal()
+    try:
+        category = session.execute(
+            select(Category).where(Category.slug == "general-knowledge")
+        ).scalar_one()
+        question = session.execute(
+            select(Question).where(Question.prompt == "What is 2 + 2?")
+        ).scalar_one()
+        quiz = session.execute(select(Quiz).where(Quiz.title == "General Quiz")).scalar_one()
+        options = session.execute(
+            select(Option).where(Option.question_id == question.id)
+        ).scalars().all()
+        quiz_questions = session.execute(
+            select(QuizQuestion).where(QuizQuestion.quiz_id == quiz.id)
+        ).scalars().all()
+    finally:
+        session.close()
+
+    assert category.description == "Mixed questions"
+    assert question.explanation == "Basic math."
+    assert len(options) == 3
+    assert any(option.is_correct for option in options)
+    assert len(quiz_questions) == 1
+
+    # preview again should mark everything as update
+    repeat_preview = client.post(
+        "/api/admin/bulk-import/preview",
+        files={
+            "file": (
+                "bulk.xlsx",
+                content,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            )
+        },
+        headers=headers,
+    )
+    assert repeat_preview.status_code == 200
+    repeat_data = repeat_preview.json()
+    assert repeat_data["categories"][0]["action"] == "update"
+    assert repeat_data["quizzes"][0]["action"] == "update"
+    assert repeat_data["questions"][0]["action"] == "update"


### PR DESCRIPTION
## Summary
- add backend schemas, parsing service, and admin endpoints to preview and commit bulk quiz/question/category imports from Excel
- introduce a Vue-based admin bulk import page with inline editing and navigation entry
- ensure JSON metadata columns and search index setup remain compatible with non-Postgres test environments and cover the flow with a backend test harness

## Testing
- `python -m pytest tests/test_bulk_import.py` *(skipped: httpx dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e92c2d4da88324956bcb6a11ed4152