### PR TITLE
Fix practice query defaults and stabilize tests

### DIFF
--- a/services/api/app/api/routes/practice.py
+++ b/services/api/app/api/routes/practice.py
@@ -203,8 +203,8 @@ def get_practice_category(
 @router.get("/bookmarks", response_model=PracticeCategoryDetail)
 def get_bookmark_revision_set(
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
-    difficulty: str | None = Query(default=None, min_length=1, max_length=50),
-    category_id: int | None = Query(default=None, ge=1),
+    difficulty: Annotated[str | None, Query(min_length=1, max_length=50)] = None,
+    category_id: Annotated[int | None, Query(ge=1)] = None,
     current_user: User = Depends(require_learner),
     db: Session = Depends(get_db_session),
 ) -> PracticeCategoryDetail:

--- a/services/api/app/api/routes/quizzes.py
+++ b/services/api/app/api/routes/quizzes.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import List
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session, selectinload
@@ -39,7 +41,7 @@ def _resolve_default_org_id(user: User) -> int | None:
 
 @router.get("/", response_model=List[QuizSummary])
 def list_quizzes(
-    organization_id: int | None = Query(default=None),
+    organization_id: Annotated[int | None, Query(ge=1)] = None,
     db: Session = Depends(get_db_session),
     current_user: User | None = Depends(get_current_user_optional),
 ) -> List[QuizSummary]:

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/services/api/tests/test_attempts_history.py
+++ b/services/api/tests/test_attempts_history.py
@@ -26,7 +26,12 @@ from app.models.user import User  # noqa: E402
 
 
 engine = create_engine("sqlite+pysqlite:///:memory:", connect_args={"check_same_thread": False})
-TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+TestingSessionLocal = sessionmaker(
+    autocommit=False,
+    autoflush=False,
+    expire_on_commit=False,
+    bind=engine,
+)
 Base.metadata.create_all(bind=engine)
 
 

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -15,7 +15,12 @@ from app.models.user import PlatformUser, User
 
 
 engine = create_engine("sqlite+pysqlite:///:memory:", connect_args={"check_same_thread": False})
-TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+TestingSessionLocal = sessionmaker(
+    autocommit=False,
+    autoflush=False,
+    expire_on_commit=False,
+    bind=engine,
+)
 Base.metadata.create_all(bind=engine)
 
 

--- a/services/api/tests/test_bookmarks.py
+++ b/services/api/tests/test_bookmarks.py
@@ -27,7 +27,12 @@ from app.models.user import User  # noqa: E402
 
 
 engine = create_engine("sqlite+pysqlite:///:memory:", connect_args={"check_same_thread": False})
-TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+TestingSessionLocal = sessionmaker(
+    autocommit=False,
+    autoflush=False,
+    expire_on_commit=False,
+    bind=engine,
+)
 Base.metadata.create_all(bind=engine)
 
 

--- a/services/api/tests/test_practice.py
+++ b/services/api/tests/test_practice.py
@@ -22,7 +22,12 @@ from app.models.user import LearnerUser, User  # noqa: E402
 
 
 engine = create_engine("sqlite+pysqlite:///:memory:", connect_args={"check_same_thread": False})
-TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+TestingSessionLocal = sessionmaker(
+    autocommit=False,
+    autoflush=False,
+    expire_on_commit=False,
+    bind=engine,
+)
 Base.metadata.create_all(bind=engine)
 
 
@@ -194,6 +199,11 @@ def seed_global_questions(db: Session) -> Category:
 
 
 def seed_questions_without_items(db: Session) -> tuple[Organization, Category]:
+    db.query(QuizQuestion).delete()
+    db.query(Quiz).delete()
+    db.query(OrgMembership).delete()
+    db.query(LearnerUser).delete()
+    db.query(User).delete()
     db.query(Option).delete()
     db.query(Question).delete()
     db.query(Category).delete()


### PR DESCRIPTION
## Summary
- normalize FastAPI query parameter defaults in practice bookmark and quiz listing endpoints so direct function calls receive plain values
- add explicit path bootstrap for the test suite and ensure sqlite sessionmakers keep objects alive after commit
- clear related tables in the practice seed helper to avoid unique constraint failures during repeated setups

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb6e7b9ae88324b327a457f5e85f32