### PR TITLE
Add subjects and topics APIs plus Vue subject explorer

### DIFF
--- a/app/web/env.d.ts
+++ b/app/web/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>QuizHub Subjects</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "quizhub-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.21",
+    "vue-router": "^4.3.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/app/web/src/App.vue
+++ b/app/web/src/App.vue
@@ -1,0 +1,60 @@
+<template>
+  <main class="app-shell">
+    <header class="hero">
+      <h1>QuizHub Subject Library</h1>
+      <p>Browse available subjects, explore topics, and jump straight into practice.</p>
+    </header>
+    <section class="content">
+      <SubjectExplorer />
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+import SubjectExplorer from './components/SubjectExplorer.vue'
+</script>
+
+<style scoped>
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2.5rem clamp(1rem, 4vw, 3.5rem);
+}
+
+.hero {
+  background: linear-gradient(135deg, #2563eb, #4f46e5);
+  color: white;
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: 0 18px 45px -20px rgba(37, 99, 235, 0.6);
+}
+
+.hero h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(2rem, 3.5vw, 2.75rem);
+  font-weight: 700;
+}
+
+.hero p {
+  margin: 0;
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  max-width: 38rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.content {
+  flex: 1;
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    padding: 1.5rem;
+  }
+
+  .hero {
+    border-radius: 1.25rem;
+  }
+}
+</style>

--- a/app/web/src/components/SubjectExplorer.vue
+++ b/app/web/src/components/SubjectExplorer.vue
@@ -1,0 +1,471 @@
+<template>
+  <div class="explorer">
+    <aside class="subject-panel">
+      <header class="panel-header">
+        <h2>Subjects</h2>
+        <div class="search">
+          <span class="search-icon" aria-hidden="true">🔍</span>
+          <input
+            v-model="search"
+            type="search"
+            placeholder="Search subjects"
+            aria-label="Filter subjects"
+          />
+        </div>
+      </header>
+
+      <div class="subject-list" role="list">
+        <button
+          v-for="subject in filteredSubjects"
+          :key="subject.id"
+          :class="['subject-pill', { active: subject.id === activeSubjectId }]"
+          type="button"
+          @click="selectSubject(subject.id)"
+        >
+          <span class="pill-icon" aria-hidden="true">{{ subject.icon ?? '📘' }}</span>
+          <div class="pill-content">
+            <strong>{{ subject.name }}</strong>
+            <small>{{ subject.description ?? 'No description yet' }}</small>
+          </div>
+          <span class="pill-meta">{{ subject.topics.length }} topics</span>
+        </button>
+
+        <p v-if="!loading && filteredSubjects.length === 0" class="empty">No subjects match your search.</p>
+      </div>
+    </aside>
+
+    <section class="subject-detail" aria-live="polite">
+      <div v-if="loading" class="state">
+        <span class="spinner" aria-hidden="true"></span>
+        <p>Loading subjects…</p>
+      </div>
+      <div v-else-if="error" class="state error">
+        <h3>Unable to load subjects</h3>
+        <p>{{ error }}</p>
+        <button type="button" class="primary" @click="loadSubjects">Try again</button>
+      </div>
+      <div v-else-if="selectedSubject" class="detail-card">
+        <header class="detail-header">
+          <span class="detail-icon" aria-hidden="true">{{ selectedSubject.icon ?? '📘' }}</span>
+          <div>
+            <h2>{{ selectedSubject.name }}</h2>
+            <p>{{ selectedSubject.description ?? 'Explore curated practice sets for this subject.' }}</p>
+          </div>
+        </header>
+
+        <section class="topics">
+          <header>
+            <h3>Topics</h3>
+            <span>{{ selectedSubject.topics.length }} available</span>
+          </header>
+
+          <div v-if="selectedSubject.topics.length > 0" class="topic-grid">
+            <article v-for="topic in selectedSubject.topics" :key="topic.id" class="topic-card">
+              <h4>{{ topic.name }}</h4>
+              <p>{{ topic.description ?? 'Review questions and quizzes tailored to this topic.' }}</p>
+              <div class="topic-actions">
+                <a
+                  class="secondary"
+                  :href="getPracticeUrl(selectedSubject.slug, topic.slug)"
+                >
+                  Practice topic
+                </a>
+              </div>
+            </article>
+          </div>
+          <p v-else class="empty">Topics have not been added for this subject yet.</p>
+        </section>
+
+        <footer class="detail-footer">
+          <a class="primary" :href="getPracticeUrl(selectedSubject.slug)">
+            Start practice set
+          </a>
+          <button type="button" class="ghost" @click="loadSubjects">Refresh</button>
+        </footer>
+      </div>
+      <div v-else class="state">
+        <h3>Select a subject to view topics</h3>
+        <p>Subjects that appear here are available to your organization or globally.</p>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+type Topic = {
+  id: number
+  slug: string
+  name: string
+  description?: string | null
+  subject_id: number
+}
+
+type Subject = {
+  id: number
+  slug: string
+  name: string
+  description?: string | null
+  icon?: string | null
+  organization_id: number | null
+  topics: Topic[]
+}
+
+const subjects = ref<Subject[]>([])
+const loading = ref(false)
+const error = ref<string | null>(null)
+const activeSubjectId = ref<number | null>(null)
+const search = ref('')
+
+const filteredSubjects = computed(() => {
+  if (!search.value.trim()) {
+    return subjects.value
+  }
+  const value = search.value.toLowerCase()
+  return subjects.value.filter((subject) =>
+    subject.name.toLowerCase().includes(value) ||
+    (subject.description ?? '').toLowerCase().includes(value)
+  )
+})
+
+const selectedSubject = computed(() =>
+  subjects.value.find((subject) => subject.id === activeSubjectId.value) ?? null
+)
+
+async function loadSubjects() {
+  loading.value = true
+  error.value = null
+  try {
+    const response = await fetch('/api/subjects')
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`)
+    }
+    const payload = (await response.json()) as Subject[]
+    subjects.value = payload
+    if (payload.length > 0) {
+      activeSubjectId.value ??= payload[0].id
+    } else {
+      activeSubjectId.value = null
+    }
+  } catch (err) {
+    console.error(err)
+    error.value = err instanceof Error ? err.message : 'Unknown error'
+  } finally {
+    loading.value = false
+  }
+}
+
+function selectSubject(id: number) {
+  activeSubjectId.value = id
+}
+
+function getPracticeUrl(subjectSlug: string, topicSlug?: string) {
+  if (topicSlug) {
+    return `/practice/categories/${subjectSlug}?topic=${encodeURIComponent(topicSlug)}`
+  }
+  return `/practice/categories/${subjectSlug}`
+}
+
+onMounted(loadSubjects)
+</script>
+
+<style scoped>
+.explorer {
+  display: grid;
+  grid-template-columns: minmax(280px, 320px) 1fr;
+  gap: 2rem;
+  align-items: stretch;
+}
+
+.subject-panel {
+  background: white;
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: 0 18px 45px -28px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  background: #f1f5f9;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  gap: 0.5rem;
+}
+
+
+.search-icon {
+  font-size: 1rem;
+  opacity: 0.6;
+}
+
+.search input {
+  border: none;
+  background: transparent;
+  outline: none;
+  flex: 1;
+  font-size: 0.95rem;
+}
+
+.subject-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: min(60vh, 540px);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.subject-pill {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid transparent;
+  background: #f8fafc;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.2s ease;
+}
+
+.subject-pill:hover {
+  transform: translateY(-1px);
+  background: #f1f5f9;
+}
+
+.subject-pill.active {
+  border-color: #2563eb;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(79, 70, 229, 0.12));
+}
+
+.pill-icon {
+  font-size: 1.6rem;
+}
+
+.pill-content strong {
+  display: block;
+  font-size: 1rem;
+  margin-bottom: 0.15rem;
+}
+
+.pill-content small {
+  color: #475569;
+  font-size: 0.85rem;
+}
+
+.pill-meta {
+  font-size: 0.8rem;
+  color: #475569;
+  font-weight: 600;
+}
+
+.subject-detail {
+  background: white;
+  border-radius: 1.25rem;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  box-shadow: 0 18px 45px -30px rgba(15, 23, 42, 0.4);
+  min-height: 420px;
+  display: flex;
+  flex-direction: column;
+}
+
+.detail-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  height: 100%;
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.detail-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #eef2ff;
+  color: #4338ca;
+  border-radius: 1rem;
+  font-size: 2rem;
+  width: 3.5rem;
+  height: 3.5rem;
+}
+
+.detail-header h2 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.detail-header p {
+  margin: 0.25rem 0 0;
+  color: #475569;
+  max-width: 45ch;
+}
+
+.topics header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.topics h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.topics header span {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.topic-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.topic-card {
+  background: #f8fafc;
+  border-radius: 1rem;
+  padding: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.topic-card h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #1f2937;
+}
+
+.topic-card p {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.9rem;
+  flex: 1;
+}
+
+.topic-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.state {
+  margin: auto;
+  text-align: center;
+  max-width: 26rem;
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.state.error h3 {
+  margin: 0;
+}
+
+.state.error p {
+  color: #b91c1c;
+}
+
+.spinner {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 3px solid #dbeafe;
+  border-top-color: #2563eb;
+  animation: spin 1s linear infinite;
+}
+
+.detail-footer {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+}
+
+.primary,
+.secondary,
+.ghost {
+  border-radius: 999px;
+  padding: 0.6rem 1.1rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.primary {
+  background: linear-gradient(135deg, #2563eb, #4f46e5);
+  color: white;
+  box-shadow: 0 10px 25px -18px rgba(37, 99, 235, 0.75);
+}
+
+.secondary {
+  background: white;
+  color: #2563eb;
+  border: 1px solid rgba(37, 99, 235, 0.25);
+}
+
+.ghost {
+  background: transparent;
+  color: #1f2937;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+}
+
+.primary:hover,
+.secondary:hover,
+.ghost:hover {
+  transform: translateY(-1px);
+}
+
+.empty {
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 960px) {
+  .explorer {
+    grid-template-columns: 1fr;
+  }
+
+  .subject-panel {
+    order: 2;
+  }
+
+  .subject-detail {
+    order: 1;
+  }
+}
+</style>

--- a/app/web/src/main.ts
+++ b/app/web/src/main.ts
@@ -1,0 +1,7 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './styles/main.css'
+
+const app = createApp(App)
+
+app.mount('#app')

--- a/app/web/src/styles/main.css
+++ b/app/web/src/styles/main.css
@@ -1,0 +1,19 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1f2933;
+  background-color: #f9fafb;
+}
+
+body {
+  margin: 0;
+  background-color: #f9fafb;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+}

--- a/app/web/tsconfig.json
+++ b/app/web/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue", "env.d.ts"],
+  "exclude": ["node_modules"]
+}

--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  server: {
+    host: true,
+    port: 5173
+  },
+  plugins: [vue()]
+})

--- a/services/api/app/api/routes/practice.py
+++ b/services/api/app/api/routes/practice.py
@@ -19,6 +19,7 @@ from app.schemas.practice import (
     PracticeQuestion,
     PracticeQuestionOption,
 )
+from app.schemas.topic import TopicOut
 
 router = APIRouter(prefix="/practice", tags=["practice"])
 
@@ -42,6 +43,7 @@ def list_practice_categories(
     categories = list(
         db.scalars(
             select(Category)
+            .options(selectinload(Category.topics))
             .where(
                 Category.organization_id == org_id
                 if org_id is not None
@@ -122,6 +124,7 @@ def list_practice_categories(
                 difficulties=difficulties,
                 quiz_id=quiz_map.get(category.id),
                 organization_id=category.organization_id,
+                topics=[TopicOut.model_validate(topic) for topic in category.topics],
             )
         )
 
@@ -139,6 +142,7 @@ def get_practice_category(
 
     category = db.scalar(
         select(Category)
+        .options(selectinload(Category.topics))
         .where(Category.slug == slug)
         .where(
             Category.organization_id == org_id
@@ -197,6 +201,7 @@ def get_practice_category(
         difficulty=difficulty_label(difficulties),
         questions=questions_payload,
         organization_id=category.organization_id,
+        topics=[TopicOut.model_validate(topic) for topic in category.topics],
     )
 
 
@@ -260,4 +265,5 @@ def get_bookmark_revision_set(
         difficulty=difficulty_label(difficulties),
         questions=questions_payload,
         organization_id=current_user.organization_id,
+        topics=[],
     )

--- a/services/api/app/api/routes/subjects.py
+++ b/services/api/app/api/routes/subjects.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, selectinload
+
+from app.api.deps import (
+    get_db_session,
+    resolve_content_organization,
+    require_content_manager,
+)
+from app.core.strings import slugify
+from app.models.category import Category
+from app.models.question import Question
+from app.models.topic import Topic
+from app.models.user import User
+from app.schemas.subject import SubjectCreate, SubjectOut, SubjectUpdate
+from app.schemas.topic import TopicCreate, TopicOut, TopicUpdate
+
+router = APIRouter(prefix="/subjects", tags=["subjects"])
+
+
+def _normalize_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def _resolve_subject(
+    db: Session,
+    subject_id: int,
+    current_user: User,
+    organization_id: int | None,
+) -> Category:
+    subject = db.get(Category, subject_id)
+    if subject is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subject not found")
+
+    target_org_id = resolve_content_organization(
+        current_user,
+        organization_id if organization_id is not None else subject.organization_id,
+        allow_global_for_admin=True,
+    )
+
+    if target_org_id is not None:
+        if subject.organization_id != target_org_id:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Subject belongs to another organization")
+    elif current_user.role != "superuser" and subject.organization_id is not None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Subject belongs to another organization")
+
+    return subject
+
+
+@router.get("/", response_model=List[SubjectOut])
+def list_subjects(
+    organization_id: int | None = Query(default=None),
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(require_content_manager),
+) -> List[SubjectOut]:
+    stmt = select(Category).options(selectinload(Category.topics)).order_by(Category.name.asc())
+
+    if organization_id is not None:
+        target_org_id = resolve_content_organization(
+            current_user,
+            organization_id,
+            allow_global_for_admin=True,
+        )
+        if target_org_id is not None:
+            stmt = stmt.where(Category.organization_id == target_org_id)
+        else:
+            stmt = stmt.where(Category.organization_id.is_(None))
+    elif current_user.role == "org_admin":
+        org_id = current_user.organization_id
+        if org_id is None:
+            return []
+        stmt = stmt.where(Category.organization_id == org_id)
+    elif current_user.role == "admin":
+        stmt = stmt.where(Category.organization_id.is_(None))
+
+    subjects = list(db.scalars(stmt))
+    return [SubjectOut.model_validate(subject) for subject in subjects]
+
+
+@router.post("/", response_model=SubjectOut, status_code=status.HTTP_201_CREATED)
+def create_subject(
+    payload: SubjectCreate,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(require_content_manager),
+    organization_id: int | None = Query(default=None),
+) -> SubjectOut:
+    name = payload.name.strip()
+    slug = slugify(name)
+    target_org_id = resolve_content_organization(
+        current_user,
+        organization_id,
+        allow_global_for_admin=True,
+    )
+
+    existing = db.scalar(
+        select(Category).where(
+            Category.slug == slug,
+            Category.organization_id == target_org_id,
+        )
+    )
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A subject with this name already exists.",
+        )
+
+    subject = Category(
+        name=name,
+        slug=slug,
+        description=_normalize_optional(payload.description),
+        icon=_normalize_optional(payload.icon),
+        organization_id=target_org_id,
+    )
+    db.add(subject)
+    db.commit()
+    db.refresh(subject)
+    return SubjectOut.model_validate(subject)
+
+
+@router.put("/{subject_id}", response_model=SubjectOut)
+def update_subject(
+    subject_id: int,
+    payload: SubjectUpdate,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(require_content_manager),
+    organization_id: int | None = Query(default=None),
+) -> SubjectOut:
+    subject = _resolve_subject(db, subject_id, current_user, organization_id)
+
+    target_org_id = resolve_content_organization(
+        current_user,
+        organization_id if organization_id is not None else subject.organization_id,
+        allow_global_for_admin=True,
+    )
+
+    if payload.name is not None:
+        new_name = payload.name.strip()
+        if not new_name:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Name cannot be empty.",
+            )
+        new_slug = slugify(new_name)
+        duplicate = db.scalar(
+            select(Category).where(
+                Category.slug == new_slug,
+                Category.id != subject.id,
+                Category.organization_id == target_org_id,
+            )
+        )
+        if duplicate is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Another subject with this name already exists.",
+            )
+        subject.name = new_name
+        subject.slug = new_slug
+
+    if payload.description is not None:
+        subject.description = _normalize_optional(payload.description)
+    if payload.icon is not None:
+        subject.icon = _normalize_optional(payload.icon)
+    if current_user.role == "org_admin" or organization_id is not None:
+        subject.organization_id = target_org_id
+
+    db.commit()
+    db.refresh(subject)
+    return SubjectOut.model_validate(subject)
+
+
+@router.delete("/{subject_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_subject(
+    subject_id: int,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(require_content_manager),
+    organization_id: int | None = Query(default=None),
+) -> None:
+    subject = _resolve_subject(db, subject_id, current_user, organization_id)
+
+    question_count = db.scalar(
+        select(func.count()).select_from(Question).where(Question.category_id == subject.id)
+    )
+    if question_count and question_count > 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Remove or reassign questions before deleting this subject.",
+        )
+
+    db.delete(subject)
+    db.commit()
+
+
+@router.get("/{subject_id}/topics", response_model=List[TopicOut])
+def list_topics(
+    subject_id: int,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(require_content_manager),
+    organization_id: int | None = Query(default=None),
+) -> List[TopicOut]:
+    subject = _resolve_subject(db, subject_id, current_user, organization_id)
+    return [TopicOut.model_validate(topic) for topic in subject.topics]
+
+
+@router.post("/{subject_id}/topics", response_model=TopicOut, status_code=status.HTTP_201_CREATED)
+def create_topic(
+    subject_id: int,
+    payload: TopicCreate,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(require_content_manager),
+    organization_id: int | None = Query(default=None),
+) -> TopicOut:
+    subject = _resolve_subject(db, subject_id, current_user, organization_id)
+
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Name cannot be empty.")
+    slug = slugify(name)
+
+    duplicate = db.scalar(
+        select(Topic).where(
+            Topic.subject_id == subject.id,
+            Topic.slug == slug,
+        )
+    )
+    if duplicate is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A topic with this name already exists for this subject.",
+        )
+
+    topic = Topic(
+        subject_id=subject.id,
+        name=name,
+        slug=slug,
+        description=_normalize_optional(payload.description),
+    )
+    db.add(topic)
+    db.commit()
+    db.refresh(topic)
+    return TopicOut.model_validate(topic)
+
+
+@router.put("/{subject_id}/topics/{topic_id}", response_model=TopicOut)
+def update_topic(
+    subject_id: int,
+    topic_id: int,
+    payload: TopicUpdate,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(require_content_manager),
+    organization_id: int | None = Query(default=None),
+) -> TopicOut:
+    subject = _resolve_subject(db, subject_id, current_user, organization_id)
+    topic = db.get(Topic, topic_id)
+    if topic is None or topic.subject_id != subject.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Topic not found")
+
+    if payload.name is not None:
+        new_name = payload.name.strip()
+        if not new_name:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Name cannot be empty.",
+            )
+        new_slug = slugify(new_name)
+        duplicate = db.scalar(
+            select(Topic).where(
+                Topic.subject_id == subject.id,
+                Topic.slug == new_slug,
+                Topic.id != topic.id,
+            )
+        )
+        if duplicate is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Another topic with this name already exists.",
+            )
+        topic.name = new_name
+        topic.slug = new_slug
+
+    if payload.description is not None:
+        topic.description = _normalize_optional(payload.description)
+
+    db.commit()
+    db.refresh(topic)
+    return TopicOut.model_validate(topic)
+
+
+@router.delete("/{subject_id}/topics/{topic_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_topic(
+    subject_id: int,
+    topic_id: int,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(require_content_manager),
+    organization_id: int | None = Query(default=None),
+) -> None:
+    subject = _resolve_subject(db, subject_id, current_user, organization_id)
+    topic = db.get(Topic, topic_id)
+    if topic is None or topic.subject_id != subject.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Topic not found")
+
+    question_count = db.scalar(
+        select(func.count()).select_from(Question).where(Question.topic_id == topic.id)
+    )
+    if question_count and question_count > 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Remove or reassign questions before deleting this topic.",
+        )
+
+    db.delete(topic)
+    db.commit()

--- a/services/api/app/db/seed.py
+++ b/services/api/app/db/seed.py
@@ -473,7 +473,7 @@ class Seeder:
             else:
                 question.explanation = record.get("explanation")
                 question.subject = record.get("subject")
-                question.topic = record.get("topic")
+                question.topic_text = record.get("topic")
                 question.difficulty = record.get("difficulty")
                 question.text_en = record.get("prompt")
                 question.category_id = category.id

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -7,6 +7,7 @@ from app.api.routes.auth import router as auth_router
 from app.api.routes.attempts import router as attempts_router
 from app.api.routes.dashboard import router as dashboard_router
 from app.api.routes.categories import router as categories_router
+from app.api.routes.subjects import router as subjects_router
 from app.api.routes.health import router as health_router
 from app.api.routes.bookmarks import router as bookmarks_router
 from app.api.routes.practice import router as practice_router
@@ -33,6 +34,7 @@ app.include_router(users_router, prefix="/api")
 app.include_router(quizzes_router, prefix="/api")
 app.include_router(questions_router, prefix="/api")
 app.include_router(categories_router, prefix="/api")
+app.include_router(subjects_router, prefix="/api")
 app.include_router(practice_router, prefix="/api")
 app.include_router(attempts_router, prefix="/api")
 app.include_router(dashboard_router, prefix="/api")

--- a/services/api/app/models/__init__.py
+++ b/services/api/app/models/__init__.py
@@ -2,6 +2,7 @@ from app.db.base import Base  # noqa: F401
 from app.models.attempt import Attempt, AttemptAnswer  # noqa: F401
 from app.models.bookmark import Bookmark  # noqa: F401
 from app.models.category import Category  # noqa: F401
+from app.models.topic import Topic  # noqa: F401
 from app.models.question import Option, Question, QuizQuestion  # noqa: F401
 from app.models.quiz import Quiz  # noqa: F401
 from app.models.organization import (  # noqa: F401

--- a/services/api/app/models/category.py
+++ b/services/api/app/models/category.py
@@ -26,6 +26,9 @@ class Category(Base):
     questions: Mapped[list["Question"]] = relationship(
         "Question", back_populates="category"
     )
+    topics: Mapped[list["Topic"]] = relationship(
+        "Topic", back_populates="subject", cascade="all, delete-orphan", order_by="Topic.name"
+    )
     organization: Mapped["Organization | None"] = relationship(
         "Organization", back_populates="categories"
     )

--- a/services/api/app/models/question.py
+++ b/services/api/app/models/question.py
@@ -19,13 +19,16 @@ class Question(Base):
     prompt: Mapped[str] = mapped_column(Text(), nullable=False)
     explanation: Mapped[str | None] = mapped_column(Text())
     subject: Mapped[str | None] = mapped_column(String(100))
-    topic: Mapped[str | None] = mapped_column(String(100))
+    topic_text: Mapped[str | None] = mapped_column("topic", String(100))
     difficulty: Mapped[str | None] = mapped_column(String(50))
     text_en: Mapped[str | None] = mapped_column(Text())
     text_ne: Mapped[str | None] = mapped_column(Text())
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, server_default="true")
     category_id: Mapped[int] = mapped_column(
         ForeignKey("categories.id", ondelete="RESTRICT"), nullable=False
+    )
+    topic_id: Mapped[int | None] = mapped_column(
+        ForeignKey("topics.id", ondelete="SET NULL"), nullable=True, index=True
     )
     organization_id: Mapped[int | None] = mapped_column(
         ForeignKey("organizations.id", ondelete="CASCADE"), nullable=True, index=True
@@ -38,12 +41,21 @@ class Question(Base):
         "QuizQuestion", back_populates="question", cascade="all, delete-orphan"
     )
     category: Mapped["Category"] = relationship("Category", back_populates="questions")
+    _topic: Mapped["Topic | None"] = relationship("Topic", back_populates="_questions")
     organization: Mapped["Organization | None"] = relationship(
         "Organization", back_populates="questions"
     )
     bookmarks: Mapped[List["Bookmark"]] = relationship(
         "Bookmark", back_populates="question", cascade="all, delete-orphan"
     )
+
+    @property
+    def topic(self) -> "Topic | None":
+        return self._topic
+
+    @topic.setter
+    def topic(self, value: "Topic | None") -> None:
+        self._topic = value
 
 
 class Option(Base):

--- a/services/api/app/models/topic.py
+++ b/services/api/app/models/topic.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from sqlalchemy import ForeignKey, Index, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class Topic(Base):
+    __tablename__ = "topics"
+    __table_args__ = (
+        UniqueConstraint("subject_id", "slug", name="uq_topics_subject_slug"),
+        UniqueConstraint("subject_id", "name", name="uq_topics_subject_name"),
+        Index("ix_topics_name", "name"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    subject_id: Mapped[int] = mapped_column(
+        ForeignKey("categories.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    slug: Mapped[str] = mapped_column(String(160), nullable=False, index=True)
+    description: Mapped[str | None] = mapped_column(Text())
+
+    subject: Mapped["Category"] = relationship("Category", back_populates="topics")
+    _questions: Mapped[list["Question"]] = relationship("Question", back_populates="_topic")
+
+
+__all__ = ["Topic"]

--- a/services/api/app/schemas/bookmark.py
+++ b/services/api/app/schemas/bookmark.py
@@ -18,5 +18,7 @@ class BookmarkOut(BaseModel):
     difficulty: str | None
     category_id: int
     category_name: str
+    topic_id: int | None
+    topic_name: str | None
 
     model_config = ConfigDict(from_attributes=True)

--- a/services/api/app/schemas/practice.py
+++ b/services/api/app/schemas/practice.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
+from app.schemas.topic import TopicOut
 
 class PracticeCategorySummary(BaseModel):
     slug: str
@@ -15,6 +16,7 @@ class PracticeCategorySummary(BaseModel):
     difficulties: List[str]
     quiz_id: Optional[int] = None
     organization_id: Optional[int] = None
+    topics: List[TopicOut] = []
 
 
 class PracticeQuestionOption(BaseModel):
@@ -48,3 +50,4 @@ class PracticeCategoryDetail(BaseModel):
     difficulty: str
     questions: List[PracticeQuestion]
     organization_id: Optional[int] = None
+    topics: List[TopicOut] = []

--- a/services/api/app/schemas/public.py
+++ b/services/api/app/schemas/public.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
+from app.schemas.topic import TopicOut
 
 class PublicCategorySummary(BaseModel):
     slug: str
@@ -13,6 +14,7 @@ class PublicCategorySummary(BaseModel):
     icon: Optional[str]
     total_questions: int
     difficulty: str
+    topics: List[TopicOut] = []
 
 
 class PublicQuizSummary(BaseModel):

--- a/services/api/app/schemas/question.py
+++ b/services/api/app/schemas/question.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 
 from app.schemas.category import CategorySummary
+from app.schemas.topic import TopicOut
 
 
 class OptionBase(BaseModel):
@@ -32,6 +33,7 @@ class QuestionBase(BaseModel):
     is_active: bool = True
     category_id: int
     organization_id: Optional[int] = None
+    topic_id: Optional[int] = None
 
 
 class QuestionCreate(QuestionBase):
@@ -46,11 +48,13 @@ class QuestionUpdate(BaseModel):
     is_active: Optional[bool] = None
     options: Optional[List[OptionCreate]] = None
     category_id: Optional[int] = None
+    topic_id: Optional[int] = None
 
 
 class QuestionOut(QuestionBase):
     id: int
     category: CategorySummary
+    topic: Optional[TopicOut] = None
     options: List[OptionOut]
 
     model_config = {
@@ -68,6 +72,8 @@ class QuestionSummary(BaseModel):
     category_id: int
     category_name: str
     organization_id: Optional[int]
+    topic_id: Optional[int]
+    topic_name: Optional[str]
 
     model_config = {
         "from_attributes": True,

--- a/services/api/app/schemas/subject.py
+++ b/services/api/app/schemas/subject.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from app.schemas.topic import TopicOut
+
+
+class SubjectBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+    icon: Optional[str] = Field(default=None, max_length=16)
+
+
+class SubjectCreate(SubjectBase):
+    pass
+
+
+class SubjectUpdate(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+    icon: Optional[str] = Field(default=None, max_length=16)
+
+
+class SubjectOut(SubjectBase):
+    id: int
+    slug: str
+    organization_id: int | None
+    topics: List[TopicOut] = []
+
+    model_config = {"from_attributes": True}
+
+
+class SubjectSummary(BaseModel):
+    id: int
+    name: str
+    slug: str
+    organization_id: int | None
+
+    model_config = {"from_attributes": True}

--- a/services/api/app/schemas/topic.py
+++ b/services/api/app/schemas/topic.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class TopicBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+
+
+class TopicCreate(TopicBase):
+    pass
+
+
+class TopicUpdate(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+
+
+class TopicOut(TopicBase):
+    id: int
+    slug: str
+    subject_id: int
+
+    model_config = {"from_attributes": True}

--- a/services/api/tests/test_bookmarks.py
+++ b/services/api/tests/test_bookmarks.py
@@ -23,6 +23,7 @@ from app.db.session import get_db  # noqa: E402
 from app.models.bookmark import Bookmark  # noqa: E402
 from app.models.category import Category  # noqa: E402
 from app.models.question import Question  # noqa: E402
+from app.models.topic import Topic  # noqa: E402
 from app.models.user import User  # noqa: E402
 
 
@@ -66,6 +67,7 @@ def reset_database():
     with TestingSessionLocal() as session:
         session.query(Bookmark).delete()
         session.query(Question).delete()
+        session.query(Topic).delete()
         session.query(Category).delete()
         session.query(User).delete()
         session.commit()
@@ -88,6 +90,16 @@ def seed_user_and_question():
         session.commit()
         session.refresh(category)
 
+        topic = Topic(
+            subject_id=category.id,
+            name="World Affairs",
+            slug="world-affairs",
+            description="Global updates",
+        )
+        session.add(topic)
+        session.commit()
+        session.refresh(topic)
+
         question = Question(
             prompt="Who is the current president?",
             explanation="The president of Nepal is Ram Chandra Poudel.",
@@ -95,24 +107,26 @@ def seed_user_and_question():
             difficulty="Medium",
             is_active=True,
             category_id=category.id,
+            topic_id=topic.id,
         )
         session.add(question)
         session.commit()
         session.refresh(question)
 
         _current_user["user"] = user
-        return user, category, question
+        return user, category, topic, question
 
 
 def test_bookmark_lifecycle():
     reset_database()
-    user, category, question = seed_user_and_question()
+    user, category, topic, question = seed_user_and_question()
 
     response = client.post("/api/bookmarks", json={"question_id": question.id})
     assert response.status_code == 201
     payload = response.json()
     assert payload["question_id"] == question.id
     assert payload["category_name"] == category.name
+    assert payload["topic_name"] == topic.name
 
     ids_response = client.get("/api/bookmarks/ids")
     assert ids_response.status_code == 200
@@ -133,7 +147,7 @@ def test_bookmark_lifecycle():
 
 def test_duplicate_bookmark_is_idempotent():
     reset_database()
-    _, category, question = seed_user_and_question()
+    _, category, topic, question = seed_user_and_question()
 
     first_response = client.post("/api/bookmarks", json={"question_id": question.id})
     assert first_response.status_code == 201
@@ -145,6 +159,7 @@ def test_duplicate_bookmark_is_idempotent():
 
     assert first_created["id"] == second_created["id"]
     assert second_created["category_name"] == category.name
+    assert second_created["topic_name"] == topic.name
 
 
 def test_bookmark_requires_question_exists():

--- a/services/api/tests/test_practice.py
+++ b/services/api/tests/test_practice.py
@@ -18,6 +18,7 @@ from app.models.category import Category  # noqa: E402
 from app.models.organization import Organization, OrgMembership  # noqa: E402
 from app.models.question import Option, Question, QuizQuestion  # noqa: E402
 from app.models.quiz import Quiz  # noqa: E402
+from app.models.topic import Topic  # noqa: E402
 from app.models.user import LearnerUser, User  # noqa: E402
 
 
@@ -39,6 +40,7 @@ def seed_questions(db: Session) -> Organization:
     db.query(User).delete()
     db.query(Option).delete()
     db.query(Question).delete()
+    db.query(Topic).delete()
     db.query(Category).delete()
     db.query(Organization).delete()
 
@@ -57,6 +59,16 @@ def seed_questions(db: Session) -> Organization:
     db.add(category)
     db.flush()
 
+    topic = Topic(
+        subject_id=category.id,
+        name="World Facts",
+        slug="world-facts",
+        description="Explore world trivia",
+    )
+
+    db.add(topic)
+    db.flush()
+
     general_question = Question(
         prompt="Capital of Nepal is Kathmandu.",
         explanation="Kathmandu is the capital city of Nepal.",
@@ -64,6 +76,7 @@ def seed_questions(db: Session) -> Organization:
         difficulty="Easy",
         is_active=True,
         category_id=category.id,
+        topic_id=topic.id,
         organization_id=organization.id,
     )
     mixed_question = Question(
@@ -73,6 +86,7 @@ def seed_questions(db: Session) -> Organization:
         difficulty="Medium",
         is_active=True,
         category_id=category.id,
+        topic_id=topic.id,
         organization_id=organization.id,
     )
 
@@ -148,6 +162,7 @@ def seed_global_questions(db: Session) -> Category:
     db.query(User).delete()
     db.query(Option).delete()
     db.query(Question).delete()
+    db.query(Topic).delete()
     db.query(Category).delete()
     db.query(Organization).delete()
 
@@ -161,6 +176,15 @@ def seed_global_questions(db: Session) -> Category:
     db.add(category)
     db.flush()
 
+    topic = Topic(
+        subject_id=category.id,
+        name="World Facts",
+        slug="world-facts",
+        description="Explore world trivia",
+    )
+    db.add(topic)
+    db.flush()
+
     general_question = Question(
         prompt="Capital of Nepal is Kathmandu.",
         explanation="Kathmandu is the capital city of Nepal.",
@@ -168,6 +192,7 @@ def seed_global_questions(db: Session) -> Category:
         difficulty="Easy",
         is_active=True,
         category_id=category.id,
+        topic_id=topic.id,
         organization_id=None,
     )
     mixed_question = Question(
@@ -177,6 +202,7 @@ def seed_global_questions(db: Session) -> Category:
         difficulty="Medium",
         is_active=True,
         category_id=category.id,
+        topic_id=topic.id,
         organization_id=None,
     )
     db.add_all([general_question, mixed_question])
@@ -239,6 +265,7 @@ def test_practice_categories_reflect_active_questions():
     assert general.difficulty == "Mixed"
     assert general.icon == "🌍"
     assert general.description is not None
+    assert [topic.slug for topic in general.topics] == ["world-facts"]
 
 
 def test_practice_categories_include_quiz_id_when_available():
@@ -283,6 +310,7 @@ def test_practice_category_detail_returns_questions():
     assert detail.icon == "🌍"
     assert all(len(question.options) == 4 for question in detail.questions)
     assert any(option.is_correct for option in detail.questions[0].options)
+    assert [topic.slug for topic in detail.topics] == ["world-facts"]
 
 
 def test_practice_category_without_questions_returns_empty_list():
@@ -312,6 +340,7 @@ def test_practice_categories_support_global_scope():
     summary = next(item for item in categories if item.slug == category.slug)
     assert summary.total_questions == 2
     assert summary.organization_id is None
+    assert [topic.slug for topic in summary.topics] == ["world-facts"]
 
 
 def test_practice_category_detail_global_scope():
@@ -327,6 +356,7 @@ def test_practice_category_detail_global_scope():
     assert detail.organization_id is None
     assert detail.total_questions == 2
     assert len(detail.questions) == 2
+    assert [topic.slug for topic in detail.topics] == ["world-facts"]
 
 
 def test_practice_bookmarks_returns_questions():


### PR DESCRIPTION
## Summary
- add Subject and Topic database models, Pydantic schemas, and REST routes to manage subject/topic hierarchies
- propagate topic awareness through practice, public, bookmark, and question APIs with refreshed tests
- scaffold a Vue frontend that lists subjects, shows topics, and links to practice flows

## Testing
- pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68eb744cdaec8324a348af5781fd3549